### PR TITLE
Don't update engine version after downloads

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "request": "attach",
             "port": 9223,
             "webRoot": "${workspaceFolder}/src/renderer",
-            "timeout": 60000
+            "timeout": 90000
         }
     ],
     "compounds": [

--- a/src/renderer/store/engine.store.ts
+++ b/src/renderer/store/engine.store.ts
@@ -17,19 +17,11 @@ export const enginesStore: {
     selectedEngineVersion: undefined,
 });
 
-async function refreshStore() {
-    enginesStore.availableEngineVersions = await window.engine.listAvailableVersions();
-    enginesStore.selectedEngineVersion = enginesStore.availableEngineVersions.find((e) => e.id === DEFAULT_ENGINE_VERSION);
-    if (!enginesStore.selectedEngineVersion) {
-        throw new Error(`Default engine version ${DEFAULT_ENGINE_VERSION} not found in available versions.`);
-    }
-}
-
 export async function downloadEngine(engineString: string) {
     await window.engine
         .downloadEngine(engineString)
         .then(async () => {
-            await refreshStore();
+            enginesStore.availableEngineVersions = await window.engine.listAvailableVersions();
         })
         .catch((error) => {
             console.error("Failed to download engine:", engineString, error);
@@ -40,12 +32,18 @@ export async function downloadEngine(engineString: string) {
 export async function initEnginesStore() {
     window.downloads.onDownloadEngineComplete(async (downloadInfo) => {
         console.debug("Received engine download completed event", downloadInfo);
-        await refreshStore();
+        enginesStore.availableEngineVersions = await window.engine.listAvailableVersions();
     });
     window.downloads.onDownloadEngineFail(async (downloadInfo) => {
         console.error("Engine download failed", downloadInfo);
-        await refreshStore();
+        enginesStore.availableEngineVersions = await window.engine.listAvailableVersions();
     });
-    await refreshStore();
+
+    enginesStore.availableEngineVersions = await window.engine.listAvailableVersions();
+    enginesStore.selectedEngineVersion = enginesStore.availableEngineVersions.find((e) => e.id === DEFAULT_ENGINE_VERSION);
+    if (!enginesStore.selectedEngineVersion) {
+        throw new Error(`Default engine version ${DEFAULT_ENGINE_VERSION} not found in available versions.`);
+    }
+
     enginesStore.isInitialized = true;
 }


### PR DESCRIPTION
Fixes #515. Refreshing the available engine versions should be decoupled from selecting the default engine version.