### PR TITLE
Fix messages popup not closing on click

### DIFF
--- a/src/renderer/components/navbar/NavBar.vue
+++ b/src/renderer/components/navbar/NavBar.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: MIT
                         v-tooltip.bottom="t('lobby.navbar.tooltips.directMessages')"
                         v-click-away:messages="() => (messagesOpen = false)"
                         :class="['icon', { active: messagesOpen }]"
-                        @click="messagesOpen = true"
+                        @click="messagesOpen = !messagesOpen"
                     >
                         <Icon :icon="messageIcon" :height="40" />
                         <div v-if="messagesUnread" class="unread-dot"></div>


### PR DESCRIPTION
The messages popup could only be opened but not closed by clicking the navbar button.

This change enables the button to toggle the popup open and closed, making it consistent with other navbar buttons.

![Recording 2026-01-31 at 20 55 24](https://github.com/user-attachments/assets/b79bb46a-613d-41f8-a9ae-2cfcaf74b234)
