### PR TITLE
add two dependencies that were not automatically installed when I ran npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,10 @@
             },
             "engines": {
                 "node": "22.18.0"
+            },
+            "optionalDependencies": {
+                "bufferutil": "^4.1.0",
+                "utf-8-validate": "^5.0.10"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -5262,6 +5266,20 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/bufferutil": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+            "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
+            }
+        },
         "node_modules/builder-util": {
             "version": "26.0.11",
             "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.0.11.tgz",
@@ -10340,6 +10358,18 @@
                 }
             }
         },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -13577,6 +13607,20 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/utf-8-validate": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+            "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
             }
         },
         "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -106,5 +106,9 @@
         "vitest": "^3.2.4",
         "vue-tsc": "^3.0.3",
         "wait-on": "^8.0.4"
+    },
+    "optionalDependencies": {
+        "bufferutil": "^4.1.0",
+        "utf-8-validate": "^5.0.10"
     }
 }


### PR DESCRIPTION
The `npm start` step failed in linux, [1] from the failing errors Google Gemini 3 llm said npm had been trying to use native versions of `bufferutil` and `utf-8-validate`. 

Google Gemini 3 recommended running `npm install bufferutil --save-optional` and `npm install utf-8-validate --save-optional` , which resulted in the below.

The bar-lobby client now works on my Linux (Ubuntu) machine when I run `npm start`, as a result of this change.


[1] original error logs were

```

ASSETS_PATH: /home/norty/hacknight/BAR-Devtools/bar-lobby/assets
STATE_PATH: /home/norty/hacknight/BAR-Devtools/bar-lobby/state
App threw an error during load
Error: Could not resolve "bufferutil" imported by "ws". Is it installed?
    at Object.<anonymous> (/home/norty/hacknight/BAR-Devtools/bar-lobby/__vite-optional-peer-dep:bufferutil:ws:true:1:25)
    at Module._compile (node:internal/modules/cjs/loader:1696:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1829:10)
    at Module.load (node:internal/modules/cjs/loader:1430:32)

```