### PR TITLE
Relax node version contraints from = to >=

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It is highly recommended to use [VSCode](https://code.visualstudio.com/) for dev
 
 ### Requirements
 
-- [Node.js 22.18.0](https://nodejs.org/en/download/)
+- [Node.js >= 22.18.0](https://nodejs.org/en/download/)
 
 We recommend tools management software like [NVM](https://github.com/nvm-sh/nvm) or [mise-en-place](https://mise.jdx.dev/) for installation of the correct node version.
 Make sure you use **the right node.js version**, check `engines.node` in [`package.json`](./package.json) for the source of truth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
                 "wait-on": "^8.0.4"
             },
             "engines": {
-                "node": ">=22.18.0"
+                "node": ">=22.18.0 <23"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
                 "wait-on": "^8.0.4"
             },
             "engines": {
-                "node": "22.18.0"
+                "node": ">=22.18.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "generate-i18n-assets": "node --import=tsx tools/generate-i18n-asset-files.ts"
     },
     "engines": {
-        "node": ">=22.18.0"
+        "node": ">=22.18.0 <23"
     },
     "dependencies": {
         "@extractus/feed-extractor": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "generate-i18n-assets": "node --import=tsx tools/generate-i18n-asset-files.ts"
     },
     "engines": {
-        "node": "22.18.0"
+        "node": ">=22.18.0"
     },
     "dependencies": {
         "@extractus/feed-extractor": "^7.1.6",


### PR DESCRIPTION
Simple change to avoid getting errors for a "too new" node version, unless there is a reason to stay specifically on `22.18.0`.
I can add "<23" if we wish to stay on `22.x` just to be safe.