### PR TITLE
Add polygon startbox preview support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "date-fns": "^4.1.0",
                 "dexie": "^4.0.11",
                 "dompurify": "^3.2.6",
+                "fengari": "^0.1.5",
                 "flag-icons": "^7.5.0",
                 "glob-promise": "^6.0.7",
                 "howler": "^2.2.4",
@@ -7720,6 +7721,17 @@
                 "pend": "~1.2.0"
             }
         },
+        "node_modules/fengari": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+            "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+            "license": "MIT",
+            "dependencies": {
+                "readline-sync": "^1.4.10",
+                "sprintf-js": "^1.1.3",
+                "tmp": "^0.2.5"
+            }
+        },
         "node_modules/figures": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -11655,6 +11667,15 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/readline-sync": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+            "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/real-require": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -12534,7 +12555,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/ssri": {
@@ -13143,10 +13163,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
-            "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
-            "dev": true,
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "date-fns": "^4.1.0",
         "dexie": "^4.0.11",
         "dompurify": "^3.2.6",
+        "fengari": "^0.1.5",
         "flag-icons": "^7.5.0",
         "glob-promise": "^6.0.7",
         "howler": "^2.2.4",

--- a/src/main/content/game/game-content.ts
+++ b/src/main/content/game/game-content.ts
@@ -225,21 +225,6 @@ export class GameContentAPI extends PrDownloaderAPI<string, GameVersion> {
     }
 
     /**
-     * Read files from a game archive by game version name and file pattern.
-     * Resolves the game version to its packageMd5 and delegates to getGameFiles.
-     * Returns parsed file data or null if the game version is not found.
-     */
-    public async readGameFiles(gameVersion: string, filePattern: string): Promise<SdpFile[] | null> {
-        const version = this.availableVersions.values().find((v) => v.gameVersion === gameVersion);
-        if (!version) return null;
-        try {
-            return await this.getGameFiles(version.packageMd5, filePattern, true);
-        } catch {
-            return null;
-        }
-    }
-
-    /**
      * @param filePatterns glob pattern for which files to retrieve
      * @example getGameFiles("Beyond All Reason test-16289-b154c3d", ["units/CorAircraft/T2/*.lua"])
      * @todo make this work for custom .sdd versions

--- a/src/main/content/game/game-content.ts
+++ b/src/main/content/game/game-content.ts
@@ -225,6 +225,21 @@ export class GameContentAPI extends PrDownloaderAPI<string, GameVersion> {
     }
 
     /**
+     * Read files from a game archive by game version name and file pattern.
+     * Resolves the game version to its packageMd5 and delegates to getGameFiles.
+     * Returns parsed file data or null if the game version is not found.
+     */
+    public async readGameFiles(gameVersion: string, filePattern: string): Promise<SdpFile[] | null> {
+        const version = this.availableVersions.values().find((v) => v.gameVersion === gameVersion);
+        if (!version) return null;
+        try {
+            return await this.getGameFiles(version.packageMd5, filePattern, true);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
      * @param filePatterns glob pattern for which files to retrieve
      * @example getGameFiles("Beyond All Reason test-16289-b154c3d", ["units/CorAircraft/T2/*.lua"])
      * @todo make this work for custom .sdd versions

--- a/src/main/content/maps/polygon-startbox-config.ts
+++ b/src/main/content/maps/polygon-startbox-config.ts
@@ -5,10 +5,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { gameContentAPI } from "@main/content/game/game-content";
 import { mapContentAPI } from "@main/content/maps/map-content";
 import { MAPS_PATHS } from "@main/config/app";
-import { parseLuaTable } from "@main/utils/parse-lua-table";
 import { evaluateLuaStartBoxScript, LuaValue } from "@main/utils/lua-evaluator";
 import { readSpecificFile } from "@main/utils/extract-7z";
 import { logger } from "@main/utils/logger";
@@ -54,11 +52,10 @@ export function invalidatePolygonConfigForMap(mapName: string): void {
 }
 
 /**
- * Load polygon startbox config for a map.
- * Priority: modside (game archive) first, then mapside (.sd7 archive).
+ * Load polygon startbox config for a map from its .sd7 archive.
  *
  * @param mapName - The map's springName (e.g., "Onyx Cauldron 2.2.2")
- * @param gameVersion - The game version string
+ * @param gameVersion - The game version string (used for cache keying)
  * @param mapWidthSpringUnits - Map width in Spring map units (multiply by 512 for elmos)
  * @param mapHeightSpringUnits - Map height in Spring map units (multiply by 512 for elmos)
  */
@@ -72,53 +69,12 @@ export async function loadPolygonStartBoxConfig(mapName: string, gameVersion: st
     const mapWidthElmos = mapWidthSpringUnits * 512;
     const mapHeightElmos = mapHeightSpringUnits * 512;
 
-    // 1) Try modside config (game archive): luarules/configs/StartBoxes/<mapName>.lua
-    const modsideResult = await tryModsideConfig(mapName, gameVersion, mapWidthElmos, mapHeightElmos);
-    if (modsideResult.found) {
-        configCache.set(key, modsideResult.config);
-        return modsideResult.config;
-    }
-
-    // 2) Try mapside config (.sd7 archive): mapconfig/map_startboxes.lua
-    const mapsideConfig = await tryMapsideConfig(mapName, mapWidthElmos, mapHeightElmos);
-    if (mapsideConfig) {
+    const config = await tryMapsideConfig(mapName, mapWidthElmos, mapHeightElmos);
+    if (config) {
         log.info(`Loaded polygon startbox config for "${mapName}" from map archive`);
-        configCache.set(key, mapsideConfig);
-        return mapsideConfig;
     }
-
-    // No config found — negative-cache
-    configCache.set(key, null);
-    return null;
-}
-
-interface ModsideResult {
-    found: boolean;
-    config: PolygonStartBoxConfig | null;
-}
-
-/** Try loading from game archive. Returns { found: true } if modside file exists (even if parsing fails). */
-async function tryModsideConfig(mapName: string, gameVersion: string, mapWidthElmos: number, mapHeightElmos: number): Promise<ModsideResult> {
-    const configPath = `luarules/configs/StartBoxes/${mapName}.lua`;
-    try {
-        const files = await gameContentAPI.readGameFiles(gameVersion, configPath);
-        if (!files || files.length === 0) {
-            return { found: false, config: null };
-        }
-        // File exists in game archive — parse it
-        const luaData = files[0].data;
-        const parsed = parseLuaTable(luaData);
-        const config = convertParsedConfig(parsed, mapWidthElmos, mapHeightElmos);
-        if (config) {
-            log.info(`Loaded polygon startbox config for "${mapName}" from game archive`);
-        } else {
-            log.warn(`Modside config for "${mapName}" found but could not be parsed`);
-        }
-        return { found: true, config };
-    } catch (err) {
-        log.debug(`No modside polygon config for "${mapName}": ${err}`);
-        return { found: false, config: null };
-    }
+    configCache.set(key, config);
+    return config;
 }
 
 /** Try loading from map .sd7 archive using fengari Lua evaluation. */
@@ -271,87 +227,6 @@ function extractPointsFromLuaObj(pointsValue: LuaValue, mapWidthElmos: number, m
     }
 
     return points;
-}
-
-/**
- * Convert parsed Lua startbox config (from parseLuaTable) to PolygonStartBoxConfig.
- * Used for modside configs where parseLuaTable returns JS arrays and numeric keys.
- */
-function convertParsedConfig(parsed: unknown, mapWidthElmos: number, mapHeightElmos: number): PolygonStartBoxConfig | null {
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    const parsedObj = parsed as Record<string, unknown>;
-    const entries: PolygonStartBoxEntry[] = [];
-
-    const teamIds = Object.keys(parsedObj)
-        .map(Number)
-        .filter((k) => !isNaN(k))
-        .sort((a, b) => a - b);
-
-    if (teamIds.length === 0) return null;
-
-    for (const teamId of teamIds) {
-        const teamData = parsedObj[teamId];
-        if (!teamData || typeof teamData !== "object" || Array.isArray(teamData)) continue;
-        const team = teamData as Record<string, unknown>;
-        if (!Array.isArray(team.boxes)) continue;
-
-        const polygons: PolygonVertex[][] = [];
-        for (const box of team.boxes) {
-            if (!Array.isArray(box)) continue;
-            const vertices: PolygonVertex[] = [];
-            for (const point of box) {
-                if (Array.isArray(point) && point.length >= 2 && typeof point[0] === "number" && typeof point[1] === "number") {
-                    vertices.push({
-                        x: point[0] / mapWidthElmos,
-                        y: point[1] / mapHeightElmos,
-                    });
-                }
-            }
-            if (vertices.length >= 3) {
-                polygons.push(vertices);
-            }
-        }
-
-        if (polygons.length === 0) continue;
-
-        const startpoints: PolygonVertex[] = [];
-        if (Array.isArray(team.startpoints)) {
-            for (const sp of team.startpoints) {
-                if (Array.isArray(sp) && sp.length >= 2 && typeof sp[0] === "number" && typeof sp[1] === "number") {
-                    startpoints.push({
-                        x: sp[0] / mapWidthElmos,
-                        y: sp[1] / mapHeightElmos,
-                    });
-                }
-            }
-        }
-
-        entries.push({
-            teamId,
-            nameLong: extractStringValue(team.nameLong),
-            nameShort: extractStringValue(team.nameShort),
-            polygons,
-            startpoints,
-            boundingBox: computeBoundingBox(polygons),
-        });
-    }
-
-    return entries.length > 0 ? { entries } : null;
-}
-
-/** Extract string from parseLuaTable output, which may be a plain string or a StringLiteral AST node. */
-function extractStringValue(val: unknown): string | undefined {
-    if (typeof val === "string") return val;
-    if (val && typeof val === "object" && "value" in val && typeof (val as { value: unknown }).value === "string") {
-        return (val as { value: string }).value;
-    }
-    if (val && typeof val === "object" && "raw" in val && typeof (val as { raw: unknown }).raw === "string") {
-        const raw = (val as { raw: string }).raw;
-        if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
-            return raw.slice(1, -1);
-        }
-    }
-    return undefined;
 }
 
 function computeBoundingBox(polygons: PolygonVertex[][]): { left: number; top: number; right: number; bottom: number } {

--- a/src/main/content/maps/polygon-startbox-config.ts
+++ b/src/main/content/maps/polygon-startbox-config.ts
@@ -2,8 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
+import * as fs from "fs";
+import * as path from "path";
+
 import { gameContentAPI } from "@main/content/game/game-content";
+import { mapContentAPI } from "@main/content/maps/map-content";
+import { MAPS_PATHS } from "@main/config/app";
 import { parseLuaTable } from "@main/utils/parse-lua-table";
+import { evaluateLuaStartBoxScript, LuaValue } from "@main/utils/lua-evaluator";
+import { readSpecificFile } from "@main/utils/extract-7z";
 import { logger } from "@main/utils/logger";
 
 const log = logger("polygon-startbox-config.ts");
@@ -28,8 +35,6 @@ export interface PolygonStartBoxConfig {
 
 // Cache: key = "mapName|gameVersion", value = config or null (negative cache)
 const configCache = new Map<string, PolygonStartBoxConfig | null>();
-// Track which cache entries are negative-cached from available archives vs missing archives
-const negativeCacheValid = new Set<string>();
 
 function cacheKey(mapName: string, gameVersion: string): string {
     return `${mapName}|${gameVersion}`;
@@ -37,25 +42,27 @@ function cacheKey(mapName: string, gameVersion: string): string {
 
 export function clearPolygonConfigCache(): void {
     configCache.clear();
-    negativeCacheValid.clear();
+}
+
+/** Invalidate cached entries for a specific map (called on map add/delete). */
+export function invalidatePolygonConfigForMap(mapName: string): void {
+    for (const key of configCache.keys()) {
+        if (key.startsWith(`${mapName}|`)) {
+            configCache.delete(key);
+        }
+    }
 }
 
 /**
- * Load polygon startbox config for a map from the game archive.
- * Priority: modside (game archive) config first.
- * Map archive fallback is not implemented (requires .sd7 extraction).
+ * Load polygon startbox config for a map.
+ * Priority: modside (game archive) first, then mapside (.sd7 archive).
  *
- * @param mapName - The map's springName (e.g., "Cirolata 1.03")
+ * @param mapName - The map's springName (e.g., "Onyx Cauldron 2.2.2")
  * @param gameVersion - The game version string
  * @param mapWidthSpringUnits - Map width in Spring map units (multiply by 512 for elmos)
  * @param mapHeightSpringUnits - Map height in Spring map units (multiply by 512 for elmos)
  */
-export async function loadPolygonStartBoxConfig(
-    mapName: string,
-    gameVersion: string,
-    mapWidthSpringUnits: number,
-    mapHeightSpringUnits: number
-): Promise<PolygonStartBoxConfig | null> {
+export async function loadPolygonStartBoxConfig(mapName: string, gameVersion: string, mapWidthSpringUnits: number, mapHeightSpringUnits: number): Promise<PolygonStartBoxConfig | null> {
     const key = cacheKey(mapName, gameVersion);
 
     if (configCache.has(key)) {
@@ -65,45 +72,217 @@ export async function loadPolygonStartBoxConfig(
     const mapWidthElmos = mapWidthSpringUnits * 512;
     const mapHeightElmos = mapHeightSpringUnits * 512;
 
-    // Try modside config (game archive): luarules/configs/StartBoxes/<mapName>.lua
-    const configPath = `luarules/configs/StartBoxes/${mapName}.lua`;
-    try {
-        const files = await gameContentAPI.readGameFiles(gameVersion, configPath);
-        if (files && files.length > 0) {
-            const luaData = files[0].data;
-            const parsed = parseLuaTable(luaData);
-            const config = convertParsedConfig(parsed, mapWidthElmos, mapHeightElmos);
-            if (config) {
-                log.info(`Loaded polygon startbox config for "${mapName}" from game archive`);
-                configCache.set(key, config);
-                negativeCacheValid.add(key);
-                return config;
-            }
-        }
-    } catch (err) {
-        log.debug(`No polygon config found for "${mapName}" in game archive: ${err}`);
+    // 1) Try modside config (game archive): luarules/configs/StartBoxes/<mapName>.lua
+    const modsideResult = await tryModsideConfig(mapName, gameVersion, mapWidthElmos, mapHeightElmos);
+    if (modsideResult.found) {
+        configCache.set(key, modsideResult.config);
+        return modsideResult.config;
     }
 
-    // No config found — only negative-cache if game version was available
-    const gameAvailable = gameContentAPI.isVersionInstalled(gameVersion);
-    if (gameAvailable) {
-        configCache.set(key, null);
-        negativeCacheValid.add(key);
+    // 2) Try mapside config (.sd7 archive): mapconfig/map_startboxes.lua
+    const mapsideConfig = await tryMapsideConfig(mapName, mapWidthElmos, mapHeightElmos);
+    if (mapsideConfig) {
+        log.info(`Loaded polygon startbox config for "${mapName}" from map archive`);
+        configCache.set(key, mapsideConfig);
+        return mapsideConfig;
     }
 
+    // No config found — negative-cache
+    configCache.set(key, null);
     return null;
 }
 
+interface ModsideResult {
+    found: boolean;
+    config: PolygonStartBoxConfig | null;
+}
+
+/** Try loading from game archive. Returns { found: true } if modside file exists (even if parsing fails). */
+async function tryModsideConfig(mapName: string, gameVersion: string, mapWidthElmos: number, mapHeightElmos: number): Promise<ModsideResult> {
+    const configPath = `luarules/configs/StartBoxes/${mapName}.lua`;
+    try {
+        const files = await gameContentAPI.readGameFiles(gameVersion, configPath);
+        if (!files || files.length === 0) {
+            return { found: false, config: null };
+        }
+        // File exists in game archive — parse it
+        const luaData = files[0].data;
+        const parsed = parseLuaTable(luaData);
+        const config = convertParsedConfig(parsed, mapWidthElmos, mapHeightElmos);
+        if (config) {
+            log.info(`Loaded polygon startbox config for "${mapName}" from game archive`);
+        } else {
+            log.warn(`Modside config for "${mapName}" found but could not be parsed`);
+        }
+        return { found: true, config };
+    } catch (err) {
+        log.debug(`No modside polygon config for "${mapName}": ${err}`);
+        return { found: false, config: null };
+    }
+}
+
+/** Try loading from map .sd7 archive using fengari Lua evaluation. */
+async function tryMapsideConfig(mapName: string, mapWidthElmos: number, mapHeightElmos: number): Promise<PolygonStartBoxConfig | null> {
+    const sd7Path = findMapSd7Path(mapName);
+    if (!sd7Path) {
+        log.debug(`No .sd7 file found for map "${mapName}"`);
+        return null;
+    }
+
+    let luaCode: string;
+    try {
+        luaCode = await readSpecificFile(sd7Path, "mapconfig/map_startboxes.lua");
+    } catch {
+        // No startbox config in this map archive — that's normal
+        return null;
+    }
+
+    if (!luaCode || luaCode.trim().length === 0) {
+        return null;
+    }
+
+    try {
+        const result = evaluateLuaStartBoxScript(luaCode, mapWidthElmos, mapHeightElmos);
+        if (!result || typeof result !== "object") {
+            log.warn(`Mapside config for "${mapName}" returned non-table result`);
+            return null;
+        }
+        return convertLuaEvalResult(result as Record<string, LuaValue>, mapWidthElmos, mapHeightElmos);
+    } catch (err) {
+        log.warn(`Failed to evaluate mapside config for "${mapName}": ${err}`);
+        return null;
+    }
+}
+
+/** Find the full .sd7 path for a map by searching MAPS_PATHS. */
+function findMapSd7Path(mapName: string): string | null {
+    const fileName = mapContentAPI.mapNameFileNameLookup[mapName];
+    if (!fileName) return null;
+
+    for (const mapsDir of MAPS_PATHS) {
+        const fullPath = path.join(mapsDir, fileName);
+        if (fs.existsSync(fullPath)) {
+            return fullPath;
+        }
+    }
+    return null;
+}
+
+type LuaTable = { [key: string]: LuaValue };
+
+function isLuaTable(v: LuaValue): v is LuaTable {
+    return v !== null && typeof v === "object";
+}
+
+/** Get sorted numeric keys from a Lua table (handles both 0-based and 1-based). */
+function numericKeysOf(table: LuaTable): number[] {
+    return Object.keys(table)
+        .map(Number)
+        .filter((k) => !isNaN(k))
+        .sort((a, b) => a - b);
+}
+
+/** Safely read a string field from a Lua table, returning undefined if not a string. */
+function luaString(table: LuaTable, key: string): string | undefined {
+    const v = table[key];
+    return typeof v === "string" ? v : undefined;
+}
+
 /**
- * Convert parsed Lua startbox config to PolygonStartBoxConfig.
- * The parsed Lua table has numeric keys (0-based allyTeamIDs) with value objects:
- *   { nameLong, nameShort, startpoints: [[x,z], ...], boxes: [[[x,z], ...], ...] }
+ * Convert fengari Lua evaluation result to PolygonStartBoxConfig.
+ * Handles both 0-based ({[0]=..., [1]=...}) and 1-based ({{...}, {...}}) Lua tables.
+ * All keys from fengari are strings (e.g., "0", "1", "boxes", "nameLong").
+ * Nested arrays are objects with 1-based string keys (e.g., {"1": {...}, "2": {...}}).
  */
-function convertParsedConfig(parsed: Record<string, unknown>, mapWidthElmos: number, mapHeightElmos: number): PolygonStartBoxConfig | null {
+function convertLuaEvalResult(parsed: Record<string, LuaValue>, mapWidthElmos: number, mapHeightElmos: number): PolygonStartBoxConfig | null {
+    const entries: PolygonStartBoxEntry[] = [];
+    const numericKeys = numericKeysOf(parsed);
+
+    if (numericKeys.length === 0) return null;
+
+    // Normalize 1-based (mapside return) to 0-based teamIds
+    const baseOffset = numericKeys[0] === 1 ? 1 : 0;
+
+    for (const key of numericKeys) {
+        const teamData = parsed[String(key)];
+        if (!isLuaTable(teamData)) continue;
+
+        const polygons = extractPolygonsFromLuaObj(teamData.boxes, mapWidthElmos, mapHeightElmos);
+        if (polygons.length === 0) continue;
+
+        const startpoints = extractPointsFromLuaObj(teamData.startpoints, mapWidthElmos, mapHeightElmos);
+
+        entries.push({
+            teamId: key - baseOffset,
+            nameLong: luaString(teamData, "nameLong"),
+            nameShort: luaString(teamData, "nameShort"),
+            polygons,
+            startpoints,
+            boundingBox: computeBoundingBox(polygons),
+        });
+    }
+
+    return entries.length > 0 ? { entries } : null;
+}
+
+/** Extract polygon arrays from a fengari Lua table (1-based string keys). */
+function extractPolygonsFromLuaObj(boxesValue: LuaValue, mapWidthElmos: number, mapHeightElmos: number): PolygonVertex[][] {
+    if (!isLuaTable(boxesValue)) return [];
+
+    const polygons: PolygonVertex[][] = [];
+
+    for (const bk of numericKeysOf(boxesValue)) {
+        const box = boxesValue[String(bk)];
+        if (!isLuaTable(box)) continue;
+
+        const vertices: PolygonVertex[] = [];
+        for (const pk of numericKeysOf(box)) {
+            const point = box[String(pk)];
+            if (!isLuaTable(point)) continue;
+            const x = point["1"];
+            const z = point["2"];
+            if (typeof x === "number" && typeof z === "number") {
+                vertices.push({ x: x / mapWidthElmos, y: z / mapHeightElmos });
+            }
+        }
+
+        if (vertices.length >= 3) {
+            polygons.push(vertices);
+        }
+    }
+
+    return polygons;
+}
+
+/** Extract startpoint coordinates from a fengari Lua table. */
+function extractPointsFromLuaObj(pointsValue: LuaValue, mapWidthElmos: number, mapHeightElmos: number): PolygonVertex[] {
+    if (!isLuaTable(pointsValue)) return [];
+
+    const points: PolygonVertex[] = [];
+
+    for (const k of numericKeysOf(pointsValue)) {
+        const pt = pointsValue[String(k)];
+        if (!isLuaTable(pt)) continue;
+        const x = pt["1"];
+        const z = pt["2"];
+        if (typeof x === "number" && typeof z === "number") {
+            points.push({ x: x / mapWidthElmos, y: z / mapHeightElmos });
+        }
+    }
+
+    return points;
+}
+
+/**
+ * Convert parsed Lua startbox config (from parseLuaTable) to PolygonStartBoxConfig.
+ * Used for modside configs where parseLuaTable returns JS arrays and numeric keys.
+ */
+function convertParsedConfig(parsed: unknown, mapWidthElmos: number, mapHeightElmos: number): PolygonStartBoxConfig | null {
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const parsedObj = parsed as Record<string, unknown>;
     const entries: PolygonStartBoxEntry[] = [];
 
-    // Iterate over numeric keys (0, 1, 2, ...)
-    const teamIds = Object.keys(parsed)
+    const teamIds = Object.keys(parsedObj)
         .map(Number)
         .filter((k) => !isNaN(k))
         .sort((a, b) => a - b);
@@ -111,17 +290,17 @@ function convertParsedConfig(parsed: Record<string, unknown>, mapWidthElmos: num
     if (teamIds.length === 0) return null;
 
     for (const teamId of teamIds) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const teamData = parsed[teamId] as any;
-        if (!teamData || !teamData.boxes) continue;
+        const teamData = parsedObj[teamId];
+        if (!teamData || typeof teamData !== "object" || Array.isArray(teamData)) continue;
+        const team = teamData as Record<string, unknown>;
+        if (!Array.isArray(team.boxes)) continue;
 
         const polygons: PolygonVertex[][] = [];
-        // boxes is an array of polygons, each polygon is an array of [x, z] pairs
-        for (const box of teamData.boxes) {
+        for (const box of team.boxes) {
             if (!Array.isArray(box)) continue;
             const vertices: PolygonVertex[] = [];
             for (const point of box) {
-                if (Array.isArray(point) && point.length >= 2) {
+                if (Array.isArray(point) && point.length >= 2 && typeof point[0] === "number" && typeof point[1] === "number") {
                     vertices.push({
                         x: point[0] / mapWidthElmos,
                         y: point[1] / mapHeightElmos,
@@ -136,9 +315,9 @@ function convertParsedConfig(parsed: Record<string, unknown>, mapWidthElmos: num
         if (polygons.length === 0) continue;
 
         const startpoints: PolygonVertex[] = [];
-        if (teamData.startpoints && Array.isArray(teamData.startpoints)) {
-            for (const sp of teamData.startpoints) {
-                if (Array.isArray(sp) && sp.length >= 2) {
+        if (Array.isArray(team.startpoints)) {
+            for (const sp of team.startpoints) {
+                if (Array.isArray(sp) && sp.length >= 2 && typeof sp[0] === "number" && typeof sp[1] === "number") {
                     startpoints.push({
                         x: sp[0] / mapWidthElmos,
                         y: sp[1] / mapHeightElmos,
@@ -147,19 +326,32 @@ function convertParsedConfig(parsed: Record<string, unknown>, mapWidthElmos: num
             }
         }
 
-        const boundingBox = computeBoundingBox(polygons);
-
         entries.push({
             teamId,
-            nameLong: typeof teamData.nameLong === "string" ? teamData.nameLong : teamData.nameLong?.value ?? teamData.nameLong?.raw?.slice(1, -1),
-            nameShort: typeof teamData.nameShort === "string" ? teamData.nameShort : teamData.nameShort?.value ?? teamData.nameShort?.raw?.slice(1, -1),
+            nameLong: extractStringValue(team.nameLong),
+            nameShort: extractStringValue(team.nameShort),
             polygons,
             startpoints,
-            boundingBox,
+            boundingBox: computeBoundingBox(polygons),
         });
     }
 
     return entries.length > 0 ? { entries } : null;
+}
+
+/** Extract string from parseLuaTable output, which may be a plain string or a StringLiteral AST node. */
+function extractStringValue(val: unknown): string | undefined {
+    if (typeof val === "string") return val;
+    if (val && typeof val === "object" && "value" in val && typeof (val as { value: unknown }).value === "string") {
+        return (val as { value: string }).value;
+    }
+    if (val && typeof val === "object" && "raw" in val && typeof (val as { raw: unknown }).raw === "string") {
+        const raw = (val as { raw: string }).raw;
+        if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
+            return raw.slice(1, -1);
+        }
+    }
+    return undefined;
 }
 
 function computeBoundingBox(polygons: PolygonVertex[][]): { left: number; top: number; right: number; bottom: number } {

--- a/src/main/content/maps/polygon-startbox-config.ts
+++ b/src/main/content/maps/polygon-startbox-config.ts
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { gameContentAPI } from "@main/content/game/game-content";
+import { parseLuaTable } from "@main/utils/parse-lua-table";
+import { logger } from "@main/utils/logger";
+
+const log = logger("polygon-startbox-config.ts");
+
+export interface PolygonVertex {
+    x: number; // [0, 1] normalized
+    y: number; // [0, 1] normalized
+}
+
+export interface PolygonStartBoxEntry {
+    teamId: number;
+    nameLong?: string;
+    nameShort?: string;
+    polygons: PolygonVertex[][]; // multiple non-contiguous regions per team
+    startpoints: PolygonVertex[];
+    boundingBox: { left: number; top: number; right: number; bottom: number };
+}
+
+export interface PolygonStartBoxConfig {
+    entries: PolygonStartBoxEntry[];
+}
+
+// Cache: key = "mapName|gameVersion", value = config or null (negative cache)
+const configCache = new Map<string, PolygonStartBoxConfig | null>();
+// Track which cache entries are negative-cached from available archives vs missing archives
+const negativeCacheValid = new Set<string>();
+
+function cacheKey(mapName: string, gameVersion: string): string {
+    return `${mapName}|${gameVersion}`;
+}
+
+export function clearPolygonConfigCache(): void {
+    configCache.clear();
+    negativeCacheValid.clear();
+}
+
+/**
+ * Load polygon startbox config for a map from the game archive.
+ * Priority: modside (game archive) config first.
+ * Map archive fallback is not implemented (requires .sd7 extraction).
+ *
+ * @param mapName - The map's springName (e.g., "Cirolata 1.03")
+ * @param gameVersion - The game version string
+ * @param mapWidthSpringUnits - Map width in Spring map units (multiply by 512 for elmos)
+ * @param mapHeightSpringUnits - Map height in Spring map units (multiply by 512 for elmos)
+ */
+export async function loadPolygonStartBoxConfig(
+    mapName: string,
+    gameVersion: string,
+    mapWidthSpringUnits: number,
+    mapHeightSpringUnits: number
+): Promise<PolygonStartBoxConfig | null> {
+    const key = cacheKey(mapName, gameVersion);
+
+    if (configCache.has(key)) {
+        return configCache.get(key) ?? null;
+    }
+
+    const mapWidthElmos = mapWidthSpringUnits * 512;
+    const mapHeightElmos = mapHeightSpringUnits * 512;
+
+    // Try modside config (game archive): luarules/configs/StartBoxes/<mapName>.lua
+    const configPath = `luarules/configs/StartBoxes/${mapName}.lua`;
+    try {
+        const files = await gameContentAPI.readGameFiles(gameVersion, configPath);
+        if (files && files.length > 0) {
+            const luaData = files[0].data;
+            const parsed = parseLuaTable(luaData);
+            const config = convertParsedConfig(parsed, mapWidthElmos, mapHeightElmos);
+            if (config) {
+                log.info(`Loaded polygon startbox config for "${mapName}" from game archive`);
+                configCache.set(key, config);
+                negativeCacheValid.add(key);
+                return config;
+            }
+        }
+    } catch (err) {
+        log.debug(`No polygon config found for "${mapName}" in game archive: ${err}`);
+    }
+
+    // No config found — only negative-cache if game version was available
+    const gameAvailable = gameContentAPI.isVersionInstalled(gameVersion);
+    if (gameAvailable) {
+        configCache.set(key, null);
+        negativeCacheValid.add(key);
+    }
+
+    return null;
+}
+
+/**
+ * Convert parsed Lua startbox config to PolygonStartBoxConfig.
+ * The parsed Lua table has numeric keys (0-based allyTeamIDs) with value objects:
+ *   { nameLong, nameShort, startpoints: [[x,z], ...], boxes: [[[x,z], ...], ...] }
+ */
+function convertParsedConfig(parsed: Record<string, unknown>, mapWidthElmos: number, mapHeightElmos: number): PolygonStartBoxConfig | null {
+    const entries: PolygonStartBoxEntry[] = [];
+
+    // Iterate over numeric keys (0, 1, 2, ...)
+    const teamIds = Object.keys(parsed)
+        .map(Number)
+        .filter((k) => !isNaN(k))
+        .sort((a, b) => a - b);
+
+    if (teamIds.length === 0) return null;
+
+    for (const teamId of teamIds) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const teamData = parsed[teamId] as any;
+        if (!teamData || !teamData.boxes) continue;
+
+        const polygons: PolygonVertex[][] = [];
+        // boxes is an array of polygons, each polygon is an array of [x, z] pairs
+        for (const box of teamData.boxes) {
+            if (!Array.isArray(box)) continue;
+            const vertices: PolygonVertex[] = [];
+            for (const point of box) {
+                if (Array.isArray(point) && point.length >= 2) {
+                    vertices.push({
+                        x: point[0] / mapWidthElmos,
+                        y: point[1] / mapHeightElmos,
+                    });
+                }
+            }
+            if (vertices.length >= 3) {
+                polygons.push(vertices);
+            }
+        }
+
+        if (polygons.length === 0) continue;
+
+        const startpoints: PolygonVertex[] = [];
+        if (teamData.startpoints && Array.isArray(teamData.startpoints)) {
+            for (const sp of teamData.startpoints) {
+                if (Array.isArray(sp) && sp.length >= 2) {
+                    startpoints.push({
+                        x: sp[0] / mapWidthElmos,
+                        y: sp[1] / mapHeightElmos,
+                    });
+                }
+            }
+        }
+
+        const boundingBox = computeBoundingBox(polygons);
+
+        entries.push({
+            teamId,
+            nameLong: typeof teamData.nameLong === "string" ? teamData.nameLong : teamData.nameLong?.value ?? teamData.nameLong?.raw?.slice(1, -1),
+            nameShort: typeof teamData.nameShort === "string" ? teamData.nameShort : teamData.nameShort?.value ?? teamData.nameShort?.raw?.slice(1, -1),
+            polygons,
+            startpoints,
+            boundingBox,
+        });
+    }
+
+    return entries.length > 0 ? { entries } : null;
+}
+
+function computeBoundingBox(polygons: PolygonVertex[][]): { left: number; top: number; right: number; bottom: number } {
+    let minX = 1,
+        minY = 1,
+        maxX = 0,
+        maxY = 0;
+
+    for (const poly of polygons) {
+        for (const v of poly) {
+            minX = Math.min(minX, v.x);
+            minY = Math.min(minY, v.y);
+            maxX = Math.max(maxX, v.x);
+            maxY = Math.max(maxY, v.y);
+        }
+    }
+
+    return {
+        left: Math.max(0, minX),
+        top: Math.max(0, minY),
+        right: Math.min(1, maxX),
+        bottom: Math.min(1, maxY),
+    };
+}
+
+/** Compute centroid of a polygon for label placement. */
+export function polygonCentroid(vertices: PolygonVertex[]): PolygonVertex {
+    let cx = 0,
+        cy = 0;
+    for (const v of vertices) {
+        cx += v.x;
+        cy += v.y;
+    }
+    return { x: cx / vertices.length, y: cy / vertices.length };
+}

--- a/src/main/game/game.ts
+++ b/src/main/game/game.ts
@@ -40,7 +40,7 @@ export class GameAPI {
     protected gameProcess: ChildProcess | null = null;
 
     public async launchBattle(battle: BattleWithMetadata): Promise<void> {
-        const script = startScriptConverter.generateScriptStr(battle);
+        const script = await startScriptConverter.generateScriptStr(battle);
         const scriptPath = path.join(WRITE_DATA_PATH, this.startScriptName);
         await fs.promises.writeFile(scriptPath, script);
         await this.launch({

--- a/src/main/services/game.service.ts
+++ b/src/main/services/game.service.ts
@@ -17,9 +17,7 @@ async function init() {
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     // Content
     ipcMain.handle("game:downloadGame", (_, version: string) => gameContentAPI.downloadGame(version));
-    ipcMain.handle("game:getPolygonStartBoxes", (_, mapName: string, gameVersion: string, mapWidth: number, mapHeight: number) =>
-        loadPolygonStartBoxConfig(mapName, gameVersion, mapWidth, mapHeight)
-    );
+    ipcMain.handle("game:getPolygonStartBoxes", (_, mapName: string, gameVersion: string, mapWidth: number, mapHeight: number) => loadPolygonStartBoxConfig(mapName, gameVersion, mapWidth, mapHeight));
     ipcMain.handle("game:getScenarios", (_, version: string) => gameContentAPI.getScenarios(version));
     ipcMain.handle("game:getInstalledVersions", () => gameContentAPI.availableVersions.values().toArray());
     ipcMain.handle("game:isVersionInstalled", (_, id: string) => gameContentAPI.isVersionInstalled(id));

--- a/src/main/services/game.service.ts
+++ b/src/main/services/game.service.ts
@@ -8,6 +8,7 @@ import { ipcMain, BarIpcWebContents } from "@main/typed-ipc";
 import { Replay } from "@main/content/replays/replay";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
 import { replayContentAPI } from "@main/content/replays/replay-content";
+import { loadPolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
 
 async function init() {
     await gameContentAPI.init();
@@ -16,6 +17,9 @@ async function init() {
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     // Content
     ipcMain.handle("game:downloadGame", (_, version: string) => gameContentAPI.downloadGame(version));
+    ipcMain.handle("game:getPolygonStartBoxes", (_, mapName: string, gameVersion: string, mapWidth: number, mapHeight: number) =>
+        loadPolygonStartBoxConfig(mapName, gameVersion, mapWidth, mapHeight)
+    );
     ipcMain.handle("game:getScenarios", (_, version: string) => gameContentAPI.getScenarios(version));
     ipcMain.handle("game:getInstalledVersions", () => gameContentAPI.availableVersions.values().toArray());
     ipcMain.handle("game:isVersionInstalled", (_, id: string) => gameContentAPI.isVersionInstalled(id));

--- a/src/main/services/maps.service.ts
+++ b/src/main/services/maps.service.ts
@@ -7,6 +7,7 @@ import { mapContentAPI } from "@main/content/maps/map-content";
 import { ipcMain, BarIpcWebContents } from "@main/typed-ipc";
 import { MapMetadata } from "@main/content/maps/map-metadata";
 import { fetchMapImages } from "@main/content/maps/map-image";
+import { invalidatePolygonConfigForMap } from "@main/content/maps/polygon-startbox-config";
 
 async function init() {
     await mapContentAPI.init();
@@ -56,9 +57,13 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 
     // Events
     mapContentAPI.onMapAdded.add((filename: string) => {
+        const springName = mapContentAPI.fileNameMapNameLookup[filename];
+        if (springName) invalidatePolygonConfigForMap(springName);
         webContents.send("maps:mapAdded", filename);
     });
     mapContentAPI.onMapDeleted.add((filename: string) => {
+        const springName = mapContentAPI.fileNameMapNameLookup[filename];
+        if (springName) invalidatePolygonConfigForMap(springName);
         webContents.send("maps:mapDeleted", filename);
     });
 }

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import type { PolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
 import type { BattleWithMetadata } from "@main/game/battle/battle-types";
 import type { DownloadInfo } from "@main/content/downloads";
 import type { EngineVersion } from "@main/content/engine/engine-version";
@@ -63,6 +64,7 @@ export type IPCCommands = {
     "engine:uninstallVersion": (version: EngineVersion) => void;
     "game:downloadGame": (version: string) => void;
     "game:getInstalledVersions": () => GameVersion[];
+    "game:getPolygonStartBoxes": (mapName: string, gameVersion: string, mapWidth: number, mapHeight: number) => PolygonStartBoxConfig | null;
     "game:getScenarios": (version: string) => Scenario[];
     "game:isVersionInstalled": (version: string) => boolean;
     "game:launchBattle": (battle: BattleWithMetadata) => Promise<void>;

--- a/src/main/utils/fengari.d.ts
+++ b/src/main/utils/fengari.d.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+declare module "fengari" {
+    export function to_luastring(str: string): Uint8Array;
+    export function to_jsstring(buf: Uint8Array): string;
+
+    export namespace lua {
+        type lua_State = object;
+        const LUA_TNONE: number;
+        const LUA_TNIL: number;
+        const LUA_TBOOLEAN: number;
+        const LUA_TNUMBER: number;
+        const LUA_TSTRING: number;
+        const LUA_TTABLE: number;
+        const LUA_TFUNCTION: number;
+        const LUA_OK: number;
+
+        function lua_type(L: lua_State, index: number): number;
+        function lua_gettop(L: lua_State): number;
+        function lua_settop(L: lua_State, index: number): void;
+        function lua_pop(L: lua_State, n: number): void;
+        function lua_absindex(L: lua_State, index: number): number;
+        function lua_tonumber(L: lua_State, index: number): number;
+        function lua_tostring(L: lua_State, index: number): Uint8Array;
+        function lua_toboolean(L: lua_State, index: number): boolean;
+        function lua_pushnil(L: lua_State): void;
+        function lua_next(L: lua_State, index: number): number;
+        function lua_close(L: lua_State): void;
+    }
+
+    export namespace lauxlib {
+        function luaL_newstate(): lua.lua_State;
+        function luaL_dostring(L: lua.lua_State, code: Uint8Array): number;
+    }
+
+    export namespace lualib {
+        function luaL_openlibs(L: lua.lua_State): void;
+    }
+}

--- a/src/main/utils/lua-evaluator.ts
+++ b/src/main/utils/lua-evaluator.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { lua, lauxlib, lualib, to_luastring, to_jsstring } from "fengari";
+import { logger } from "@main/utils/logger";
+
+const log = logger("lua-evaluator.ts");
+
+export type LuaValue = number | string | boolean | null | { [key: string]: LuaValue };
+
+/**
+ * Evaluate a Lua startbox config script and return the first return value as a JS object.
+ *
+ * Provides mock globals so map configs can reference:
+ * - Game.mapSizeX, Game.mapSizeZ (map dimensions in elmos)
+ * - Spring.Utilities.Gametype.isFFA(), isChickens(), isCoop(), isTeams()
+ */
+export function evaluateLuaStartBoxScript(luaCode: string, mapWidthElmos: number, mapHeightElmos: number): LuaValue {
+    const L = lauxlib.luaL_newstate();
+    lualib.luaL_openlibs(L);
+
+    try {
+        // Set up mock globals matching Spring engine environment.
+        // Provide both camelCase (ZK-style mapside configs) and PascalCase (BAR engine)
+        // method names, plus ZK-specific aliases (e.g. isChickens → IsRaptors).
+        const globals =
+            `Game = { mapSizeX = ${mapWidthElmos}, mapSizeZ = ${mapHeightElmos} }\n` +
+            `local _false = function() return false end\n` +
+            `local _true = function() return true end\n` +
+            `Spring = { Utilities = { Gametype = setmetatable({\n` +
+            `  IsFFA = _false, isFFA = _false,\n` +
+            `  IsTeams = _true, isTeams = _true,\n` +
+            `  Is1v1 = _false, is1v1 = _false,\n` +
+            `  IsBigTeams = _false, isBigTeams = _false,\n` +
+            `  IsSmallTeams = _false, isSmallTeams = _false,\n` +
+            `  IsRaptors = _false, isRaptors = _false, isChickens = _false,\n` +
+            `  IsScavengers = _false, isScavengers = _false,\n` +
+            `  IsPvE = _false, isPvE = _false,\n` +
+            `  IsCoop = _false, isCoop = _false,\n` +
+            `  IsSinglePlayer = _false, isSinglePlayer = _false,\n` +
+            `  IsSandbox = _false, isSandbox = _false,\n` +
+            `}, { __index = function() return _false end }) }}`;
+
+        let result = lauxlib.luaL_dostring(L, to_luastring(globals));
+        if (result !== lua.LUA_OK) {
+            const err = to_jsstring(lua.lua_tostring(L, -1));
+            throw new Error(`Failed to set up Lua globals: ${err}`);
+        }
+
+        // Wrap the script in a function to capture the first return value
+        const wrapped = `local _f = function()\n${luaCode}\nend\nlocal _layout, _counts = _f()\nreturn _layout`;
+
+        result = lauxlib.luaL_dostring(L, to_luastring(wrapped));
+        if (result !== lua.LUA_OK) {
+            const err = to_jsstring(lua.lua_tostring(L, -1));
+            throw new Error(`Lua evaluation failed: ${err}`);
+        }
+
+        if (lua.lua_gettop(L) === 0) {
+            throw new Error("Lua script returned no values");
+        }
+
+        return luaToJS(L, -1);
+    } finally {
+        lua.lua_close(L);
+    }
+}
+
+/** Recursively convert a Lua value on the stack to a JS value. */
+function luaToJS(L: lua.lua_State, idx: number): LuaValue {
+    const t = lua.lua_type(L, idx);
+
+    switch (t) {
+        case lua.LUA_TNUMBER:
+            return lua.lua_tonumber(L, idx);
+        case lua.LUA_TSTRING:
+            return to_jsstring(lua.lua_tostring(L, idx));
+        case lua.LUA_TBOOLEAN:
+            return lua.lua_toboolean(L, idx);
+        case lua.LUA_TNIL:
+            return null;
+        case lua.LUA_TTABLE: {
+            const absIdx = lua.lua_absindex(L, idx);
+            const obj: { [key: string]: LuaValue } = {};
+            lua.lua_pushnil(L);
+            while (lua.lua_next(L, absIdx) !== 0) {
+                const key = luaToJS(L, -2);
+                const val = luaToJS(L, -1);
+                if (key !== null) {
+                    obj[String(key)] = val;
+                }
+                lua.lua_pop(L, 1);
+            }
+            return obj;
+        }
+        default:
+            return null;
+    }
+}

--- a/src/main/utils/lua-evaluator.ts
+++ b/src/main/utils/lua-evaluator.ts
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 import { lua, lauxlib, lualib, to_luastring, to_jsstring } from "fengari";
-import { logger } from "@main/utils/logger";
-
-const log = logger("lua-evaluator.ts");
 
 export type LuaValue = number | string | boolean | null | { [key: string]: LuaValue };
 

--- a/src/main/utils/parse-lua-table.ts
+++ b/src/main/utils/parse-lua-table.ts
@@ -45,16 +45,22 @@ export function parseLuaTable(luaFile: Buffer, options?: ParseLuaTableOptions): 
 function luaTableToObj(table: TableConstructorExpression): any {
     const blocks: any[] = [];
     const obj: Record<string, unknown> = {};
+    let hasKeyedFields = false;
     for (const field of table.fields) {
         if (field.type === "TableKeyString") {
             const key = field.key.name;
             const value = field.value;
             obj[key] = parseLuaAst(value);
+            hasKeyedFields = true;
+        } else if (field.type === "TableKey") {
+            const key = parseLuaAst(field.key);
+            obj[key] = parseLuaAst(field.value);
+            hasKeyedFields = true;
         } else if (field.type === "TableValue") {
             blocks.push(parseLuaAst(field.value));
         }
     }
-    return blocks.length > 0 ? blocks : obj;
+    return blocks.length > 0 && !hasKeyedFields ? blocks : blocks.length > 0 ? [...blocks, ...Object.values(obj)] : obj;
 }
 
 function parseLuaAst(value: Expression) {

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { spadsPointsToLTRBPercent } from "@main/content/maps/box-utils";
+import { loadPolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
 import { BattleWithMetadata, isPlayer, StartPosType } from "@main/game/battle/battle-types";
 import { AllyTeam, Bot, Game, Player, Team } from "@main/model/start-script";
 
@@ -15,10 +16,10 @@ import { AllyTeam, Bot, Game, Player, Team } from "@main/model/start-script";
  * - parse and convert restrictions
  */
 class StartScriptConverter {
-    public generateScriptStr(battle: BattleWithMetadata): string {
+    public async generateScriptStr(battle: BattleWithMetadata): Promise<string> {
         let scriptStr = "";
         if (!battle.isOnline) {
-            const script = this.offlineBattleToStartScript(battle);
+            const script = await this.offlineBattleToStartScript(battle);
             scriptStr = this.generateScriptString(script);
         } else {
             throw new Error("Online battles are not supported yet");
@@ -35,11 +36,27 @@ class StartScriptConverter {
         return obj;
     }
 
-    protected offlineBattleToStartScript(battle: BattleWithMetadata): Game {
+    protected async offlineBattleToStartScript(battle: BattleWithMetadata): Promise<Game> {
         const allyTeams: AllyTeam[] = [];
         const teams: Team[] = [];
         const players: Player[] = [];
         const bots: Bot[] = [];
+
+        // Pre-load polygon config for this map/game if available
+        let polygonConfig = null;
+        if (battle.battleOptions.map && battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes) {
+            const mapName = battle.battleOptions.map.springName;
+            const gameVersion = battle.battleOptions.gameVersion;
+            const mapWidth = battle.battleOptions.map.mapWidth ?? 0;
+            const mapHeight = battle.battleOptions.map.mapHeight ?? 0;
+            if (mapWidth > 0 && mapHeight > 0) {
+                try {
+                    polygonConfig = await loadPolygonStartBoxConfig(mapName, gameVersion, mapWidth, mapHeight);
+                } catch (e) {
+                    console.warn("Failed to load polygon config for start script:", e);
+                }
+            }
+        }
 
         Object.entries(battle.teams).forEach((entry) => {
             const teamId = Number(entry[0]);
@@ -54,7 +71,20 @@ class StartScriptConverter {
                 const startBoxesIndex = battle.battleOptions.mapOptions.startBoxesIndex;
                 const customStartBoxes = battle.battleOptions.mapOptions.customStartBoxes;
 
-                if (typeof startBoxesIndex === "number" && !Number.isNaN(startBoxesIndex) && Number(startBoxesIndex) >= 0) {
+                // Use polygon bounding boxes when on default preset and polygon config is available
+                if (polygonConfig && typeof startBoxesIndex === "number" && startBoxesIndex === 0) {
+                    const polyEntry = polygonConfig.entries.find((e) => e.teamId === allyTeam.id);
+                    if (polyEntry?.boundingBox) {
+                        Object.assign(allyTeam, {
+                            startrectleft: polyEntry.boundingBox.left,
+                            startrecttop: polyEntry.boundingBox.top,
+                            startrectright: polyEntry.boundingBox.right,
+                            startrectbottom: polyEntry.boundingBox.bottom,
+                        });
+                    } else {
+                        console.warn(`Ally team ${allyTeam.id} has no polygon startbox entry`);
+                    }
+                } else if (typeof startBoxesIndex === "number" && !Number.isNaN(startBoxesIndex) && Number(startBoxesIndex) >= 0) {
                     if (!battle.battleOptions.map) throw new Error("failed to access battle options map");
 
                     const startBoxes = battle.battleOptions.map.startboxesSet[startBoxesIndex].startboxes;

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { spadsPointsToLTRBPercent } from "@main/content/maps/box-utils";
-import { loadPolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
+import { loadPolygonStartBoxConfig, PolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
 import { BattleWithMetadata, isPlayer, StartPosType } from "@main/game/battle/battle-types";
 import { AllyTeam, Bot, Game, Player, Team } from "@main/model/start-script";
 
@@ -43,8 +43,8 @@ class StartScriptConverter {
         const bots: Bot[] = [];
 
         // Pre-load polygon config for this map/game if available
-        let polygonConfig = null;
-        if (battle.battleOptions.map && battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes) {
+        let polygonConfig: PolygonStartBoxConfig | null = null;
+        if (battle.battleOptions.map && battle.battleOptions.gameVersion && battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes) {
             const mapName = battle.battleOptions.map.springName;
             const gameVersion = battle.battleOptions.gameVersion;
             const mapWidth = battle.battleOptions.map.mapWidth ?? 0;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -8,6 +8,7 @@ import { Replay } from "@main/content/replays/replay";
 import { Settings } from "@main/services/settings.service";
 import { EngineVersion } from "@main/content/engine/engine-version";
 import { GameVersion } from "@main/content/game/game-version";
+import { PolygonStartBoxConfig } from "@main/content/maps/polygon-startbox-config";
 import { MapData, MapDownloadData } from "@main/content/maps/map-data";
 import { DownloadInfo } from "@main/content/downloads";
 import { Info } from "@main/services/info.service";
@@ -98,6 +99,8 @@ contextBridge.exposeInMainWorld("engine", engineApi);
 const gameApi = {
     // Content
     downloadGame: (version: string): Promise<void> => ipcRenderer.invoke("game:downloadGame", version),
+    getPolygonStartBoxes: (mapName: string, gameVersion: string, mapWidth: number, mapHeight: number): Promise<PolygonStartBoxConfig | null> =>
+        ipcRenderer.invoke("game:getPolygonStartBoxes", mapName, gameVersion, mapWidth, mapHeight),
     getScenarios: (version: string) => ipcRenderer.invoke("game:getScenarios", version),
     getInstalledVersions: (): Promise<GameVersion[]> => ipcRenderer.invoke("game:getInstalledVersions"),
     isVersionInstalled: (version: string): Promise<boolean> => ipcRenderer.invoke("game:isVersionInstalled", version),

--- a/src/renderer/components/battle/MapOptionsModal.vue
+++ b/src/renderer/components/battle/MapOptionsModal.vue
@@ -131,7 +131,7 @@ import { Ref, ref, watch, computed } from "vue";
 import Modal from "@renderer/components/common/Modal.vue";
 import Button from "@renderer/components/controls/Button.vue";
 import Range from "@renderer/components/controls/Range.vue";
-import { battleStore, battleActions } from "@renderer/store/battle.store";
+import { battleStore, battleActions, polygonStartBoxConfig, polygonPresetActive } from "@renderer/store/battle.store";
 import { isPlayer, StartBoxOrientation, StartPosType, Team } from "@main/game/battle/battle-types";
 import MapBattlePreview from "@renderer/components/maps/MapBattlePreview.vue";
 import { getBoxes } from "@renderer/utils/start-boxes";
@@ -204,10 +204,18 @@ function setPresetStartBoxes(startBoxIndex: number) {
     delete battleStore.battleOptions.mapOptions.fixedPositionsIndex;
     battleStore.battleOptions.mapOptions.startPosType = StartPosType.Boxes;
     battleStore.battleOptions.mapOptions.startBoxesIndex = startBoxIndex;
+
+    // Activate polygon mode if polygon config exists and we're selecting the default preset (index 0)
+    if (startBoxIndex === 0 && polygonStartBoxConfig.value) {
+        polygonPresetActive.value = true;
+    } else {
+        polygonPresetActive.value = false;
+    }
 }
 
 function setCustomStartBoxes(orientation: StartBoxOrientation) {
     lastSelectedCustomPresetBoxes.value = orientation;
+    polygonPresetActive.value = false;
 
     const customStartBoxes = getBoxes(orientation, customBoxRange.value);
     delete battleStore.battleOptions.mapOptions.startBoxesIndex;

--- a/src/renderer/components/maps/MapBattlePreview.vue
+++ b/src/renderer/components/maps/MapBattlePreview.vue
@@ -8,11 +8,16 @@ SPDX-License-Identifier: MIT
     <div class="map-container">
         <div v-if="battleStore.battleOptions.map" class="map" :style="aspectRatioDrivenStyle">
             <img loading="lazy" :src="mapTextureUrl" />
-            <div v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes && !polygonPresetActive" class="boxes">
+            <div
+                v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes && !polygonPresetActive"
+                class="boxes"
+            >
                 <MapBattlePreviewStartBox v-for="(box, i) in boxes" v-startBox="box" :key="`box${i}`" :id="i" :box="box" />
             </div>
             <svg
-                v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && polygonPresetActive && polygonStartBoxConfig"
+                v-if="
+                    battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && polygonPresetActive && polygonStartBoxConfig
+                "
                 class="polygon-overlay"
                 viewBox="0 0 1 1"
                 preserveAspectRatio="none"

--- a/src/renderer/components/maps/MapBattlePreview.vue
+++ b/src/renderer/components/maps/MapBattlePreview.vue
@@ -8,9 +8,33 @@ SPDX-License-Identifier: MIT
     <div class="map-container">
         <div v-if="battleStore.battleOptions.map" class="map" :style="aspectRatioDrivenStyle">
             <img loading="lazy" :src="mapTextureUrl" />
-            <div v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes" class="boxes">
+            <div v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes && !polygonPresetActive" class="boxes">
                 <MapBattlePreviewStartBox v-for="(box, i) in boxes" v-startBox="box" :key="`box${i}`" :id="i" :box="box" />
             </div>
+            <svg
+                v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && polygonPresetActive && polygonStartBoxConfig"
+                class="polygon-overlay"
+                viewBox="0 0 1 1"
+                preserveAspectRatio="none"
+            >
+                <template v-for="entry in polygonStartBoxConfig.entries" :key="`team-${entry.teamId}`">
+                    <polygon
+                        v-for="(poly, polyIdx) in entry.polygons"
+                        :key="`poly-${entry.teamId}-${polyIdx}`"
+                        :points="polygonPointsToSvg(poly)"
+                        class="startbox-polygon"
+                    />
+                    <text
+                        v-for="(poly, polyIdx) in entry.polygons"
+                        :key="`label-${entry.teamId}-${polyIdx}`"
+                        :x="polygonCentroid(poly).x"
+                        :y="polygonCentroid(poly).y"
+                        class="startbox-label"
+                    >
+                        {{ entry.teamId + 1 }}
+                    </text>
+                </template>
+            </svg>
             <div
                 v-if="battleStore.battleOptions.mapOptions.startPosType in [StartPosType.Fixed, StartPosType.Random]"
                 class="start-positions"
@@ -51,7 +75,8 @@ import { useImageBlobUrlCache } from "@renderer/composables/useImageBlobUrlCache
 import vSetPlayerColor from "@renderer/directives/vSetPlayerColor";
 import vStartBox from "@renderer/directives/vStartBox";
 import vStartPos from "@renderer/directives/vStartPos";
-import { battleActions, battleStore } from "@renderer/store/battle.store";
+import { battleActions, battleStore, polygonStartBoxConfig, polygonPresetActive } from "@renderer/store/battle.store";
+import { polygonCentroid, polygonPointsToSvg } from "@renderer/utils/polygon-start-boxes";
 import { StartBox } from "tachyon-protocol/types";
 import { computed, defineComponent, ref, watch } from "vue";
 import MapBattlePreviewStartBox from "@renderer/components/maps/MapBattlePreviewStartBox.vue";
@@ -142,6 +167,34 @@ const rgbColors = [
     position: absolute;
     width: 100%;
     height: 100%;
+}
+
+.polygon-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+}
+
+.startbox-polygon {
+    fill: rgba(200, 200, 200, 0.15);
+    stroke: rgba(255, 255, 255, 1);
+    stroke-width: 0.004;
+    stroke-dasharray: 0.01 0.006;
+}
+
+.startbox-label {
+    fill: rgba(255, 255, 255, 0.9);
+    font-size: 0.07px;
+    text-anchor: middle;
+    dominant-baseline: central;
+    font-weight: bold;
+    paint-order: stroke;
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 0.005px;
 }
 
 .start-positions {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -518,6 +518,7 @@ watch(
         if (!gameVersion) throw new Error("failed to access game version");
 
         battleStore.battleOptions.gameVersion = gameVersion.gameVersion;
+        loadPolygonConfig();
     }
 );
 

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -12,8 +12,10 @@ import { getRandomMap } from "@renderer/store/maps.store";
 import { me } from "@renderer/store/me.store";
 import { deepToRaw } from "@renderer/utils/deep-toraw";
 import { spadsBoxToStartBox } from "@renderer/utils/start-boxes";
+import { polygonConfigToStartBoxes } from "@renderer/utils/polygon-start-boxes";
+import type { PolygonStartBoxConfig } from "@renderer/utils/polygon-start-boxes";
 import { StartBox } from "tachyon-protocol/types";
-import { reactive, readonly, watch } from "vue";
+import { reactive, readonly, ref, watch } from "vue";
 import { startBattle as startGame } from "@renderer/store/game.store";
 import { setupI18n } from "@renderer/i18n";
 
@@ -24,6 +26,47 @@ interface BattleLobby {
     isJoined: boolean;
     isLobbyOpened: boolean;
     isSelectingGameMode: boolean;
+}
+
+// Polygon startbox state — separate from battle store to avoid deep-watch churn
+export const polygonStartBoxConfig = ref<PolygonStartBoxConfig | null>(null);
+export const polygonPresetActive = ref(false);
+let polygonLoadGeneration = 0;
+
+async function loadPolygonConfig() {
+    const map = battleStore.battleOptions.map;
+    const gameVersion = battleStore.battleOptions.gameVersion;
+    if (!map?.springName || !gameVersion || !map.mapWidth || !map.mapHeight) {
+        polygonStartBoxConfig.value = null;
+        polygonPresetActive.value = false;
+        return;
+    }
+
+    const generation = ++polygonLoadGeneration;
+
+    try {
+        const config = await window.game.getPolygonStartBoxes(map.springName, gameVersion, map.mapWidth, map.mapHeight);
+        // Guard against stale responses
+        if (generation !== polygonLoadGeneration) return;
+
+        polygonStartBoxConfig.value = config;
+        // Auto-activate polygon mode when config is found and we're on the default preset
+        if (config && battleStore.battleOptions.mapOptions.startBoxesIndex === 0) {
+            polygonPresetActive.value = true;
+        } else {
+            polygonPresetActive.value = false;
+        }
+    } catch {
+        if (generation !== polygonLoadGeneration) return;
+        polygonStartBoxConfig.value = null;
+        polygonPresetActive.value = false;
+    }
+}
+
+function clearPolygonState() {
+    polygonStartBoxConfig.value = null;
+    polygonPresetActive.value = false;
+    polygonLoadGeneration++;
 }
 
 // Store
@@ -209,6 +252,11 @@ function moveBotToTeam(bot: Bot, teamId: number) {
 function getNumberOfTeams(): number {
     let numberOfTeams = 2;
 
+    // Polygon mode: derive team count from polygon config
+    if (polygonPresetActive.value && polygonStartBoxConfig.value) {
+        return polygonStartBoxConfig.value.entries.length;
+    }
+
     const map = battleStore.battleOptions.map;
 
     if (!map) throw new Error("failed to access battle options map");
@@ -290,6 +338,11 @@ function updateTeams() {
 }
 
 function getCurrentStartBoxes(): Array<StartBox> {
+    // When polygon mode is active, return bounding boxes for compatibility
+    if (polygonPresetActive.value && polygonStartBoxConfig.value) {
+        return polygonConfigToStartBoxes(polygonStartBoxConfig.value);
+    }
+
     const startBoxesIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
     if (startBoxesIndex != undefined) {
         if (battleStore.battleOptions.map?.startboxesSet[startBoxesIndex] != undefined) {
@@ -443,6 +496,7 @@ watch(
         battleStore.battleOptions.mapOptions.startPosType = StartPosType.Boxes;
         battleStore.battleOptions.mapOptions.startBoxesIndex = 0;
         if (battleStore.me) battleStore.me.contentSyncState.map = battleStore.battleOptions.map?.isInstalled ? 1 : 0;
+        loadPolygonConfig();
         updateTeams();
     },
     { deep: true }
@@ -469,6 +523,7 @@ watch(
 
 function leaveBattle() {
     battleStore.isJoined = false;
+    clearPolygonState();
     resetToDefaultBattle();
 }
 
@@ -612,6 +667,8 @@ export const battleActions = {
     loadGameMode,
     getMaxPlayersPerTeam,
     getCurrentStartBoxes,
+    loadPolygonConfig,
+    clearPolygonState,
 };
 
 // Needs game files to exists.

--- a/src/renderer/utils/polygon-start-boxes.ts
+++ b/src/renderer/utils/polygon-start-boxes.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import type { PolygonStartBoxConfig, PolygonStartBoxEntry, PolygonVertex } from "@main/content/maps/polygon-startbox-config";
+import type { StartBox } from "tachyon-protocol/types";
+
+export type { PolygonStartBoxConfig, PolygonStartBoxEntry, PolygonVertex };
+
+/** Compute centroid of a polygon for label placement. */
+export function polygonCentroid(vertices: PolygonVertex[]): PolygonVertex {
+    let cx = 0,
+        cy = 0;
+    for (const v of vertices) {
+        cx += v.x;
+        cy += v.y;
+    }
+    return { x: cx / vertices.length, y: cy / vertices.length };
+}
+
+/** Convert polygon bounding boxes to StartBox array for compatibility. */
+export function polygonConfigToStartBoxes(config: PolygonStartBoxConfig): StartBox[] {
+    return config.entries.map((entry) => ({
+        left: entry.boundingBox.left,
+        top: entry.boundingBox.top,
+        right: entry.boundingBox.right,
+        bottom: entry.boundingBox.bottom,
+    }));
+}
+
+/** Convert SVG polygon points array to a points attribute string. */
+export function polygonPointsToSvg(vertices: PolygonVertex[]): string {
+    return vertices.map((v) => `${v.x},${v.y}`).join(" ");
+}


### PR DESCRIPTION
### Work done

Renders polygon startbox regions on the map preview for maps with polygon configs (e.g., Cirolata 1.03). Companion to [beyond-all-reason/Beyond-All-Reason#7513](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513) and [beyond-all-reason/BYAR-Chobby#1184](https://github.com/beyond-all-reason/BYAR-Chobby/pull/1184).

- Loads polygon configs from game archive (modside priority) or map archive (.sd7), matching the game-side priority order in `startbox_utilities.lua`
- Mapside configs use full Lua evaluation via fengari (Lua 5.3 in JS) with mock Spring/Game globals — handles conditionals, variable references, and computed values
- SVG polygon overlays on `MapBattlePreview` with team labels
- Generates engine startrects from polygon bounding boxes for game launch
- Caches configs by (mapName, gameVersion) with negative-cache and invalidation on map add/delete
- Startbox preset selector remains functional — selecting a rectangular preset overrides polygons, "Default Boxes" restores them
- Backwards compatible — maps without polygon configs behave exactly as before

#### Setup

Requires a game build from [beyond-all-reason/Beyond-All-Reason#7513](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513) and a map with polygon startbox config (e.g., Cirolata 1.03 or Onyx Cauldron).

#### Test steps

- Load chosen map in skirmish. Polygon startboxes render on map preview with team labels.
- Select a rectangular preset from the startbox dropdown. Polygons clear, rectangles appear.
- Select "Default Boxes". Polygons restore.
- Load a rectangular-only map. Existing behavior unchanged.
- Start a skirmish game on Cirolata 1.03. Game loads with correct startrects.

### Related PRs

- Core Game - https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513
- Chobby Lobby - https://github.com/beyond-all-reason/BYAR-Chobby/pull/1184

### AI / LLM usage statement

Developed with GitHub Copilot (Claude). Used for implementation, debugging, and codebase research. All code was reviewed, tested in the lobby across multiple maps and configurations, and verified by the contributor.