### PR TITLE
Allow polygon start boxes

### DIFF
--- a/src/main/content/maps/box-utils.ts
+++ b/src/main/content/maps/box-utils.ts
@@ -2,28 +2,22 @@
 //
 // SPDX-License-Identifier: MIT
 
-//Boxes
-export function pointsToXYWH(points: { x: number; y: number }[]) {
-    if (points.length !== 2) {
-        throw new Error("pointsToXYWH expects exactly 2 points");
-    }
-    const xs = points.map((point) => point.x);
-    const ys = points.map((point) => point.y);
-    const x = Math.min(...xs);
-    const y = Math.min(...ys);
-    const w = Math.max(...xs) - x;
-    const h = Math.max(...ys) - y;
-    return { x, y, w, h };
-}
-
+// Accepts either:
+//   - 2 points (legacy axis-aligned rectangle: top-left + bottom-right)
+//   - 3+ points (closed polygon ring; bounding box is computed)
+// The polygon-shape itself is preserved upstream of this helper and rendered
+// as an SVG overlay; rect-only consumers (engine start script, Tachyon
+// protocol, lobby drag-edit) operate on the bounding-box rectangle.
 export function spadsPointsToLTRBPercent(points: { x: number; y: number }[]) {
-    if (points.length !== 2) {
-        throw new Error("SpadsPointsToLTRBPercent expects exactly 2 points");
+    if (points.length < 2) {
+        throw new Error("SpadsPointsToLTRBPercent needs at least 2 points");
     }
+    const xs = points.map((p) => p.x);
+    const ys = points.map((p) => p.y);
     return {
-        left: points[0].x / 200,
-        top: points[0].y / 200,
-        right: points[1].x / 200,
-        bottom: points[1].y / 200,
+        left: Math.min(...xs) / 200,
+        top: Math.min(...ys) / 200,
+        right: Math.max(...xs) / 200,
+        bottom: Math.max(...ys) / 200,
     };
 }

--- a/src/main/content/maps/map-metadata.ts
+++ b/src/main/content/maps/map-metadata.ts
@@ -34,6 +34,15 @@ export interface MapMetadata {
 export interface StartBoxPoly {
     x: number;
     y: number;
+    /**
+     * Optional Catmull-Rom spline strength in [0, 1]. Present only on
+     * 3+ point polygon startboxes (never on 2-point legacy rectangles).
+     *   0 (or omitted) = sharp polygon corner
+     *   1             = full smooth curve
+     * Per-edge tension is the average of the two endpoint anchor strengths.
+     * Mirrors the schema in beyond-all-reason/maps-metadata#615.
+     */
+    strength?: number;
 }
 
 export interface Startbox {

--- a/src/renderer/components/maps/MapBattlePreview.vue
+++ b/src/renderer/components/maps/MapBattlePreview.vue
@@ -39,7 +39,8 @@ SPDX-License-Identifier: MIT
                     :d="shape.path"
                     fill="rgba(255, 255, 255, 0.08)"
                     stroke="rgba(255, 255, 255, 0.9)"
-                    stroke-width="0.6"
+                    stroke-dasharray="6, 6"
+                    stroke-width="1.5"
                     vector-effect="non-scaling-stroke"
                 />
             </svg>

--- a/src/renderer/components/maps/MapBattlePreview.vue
+++ b/src/renderer/components/maps/MapBattlePreview.vue
@@ -8,9 +8,41 @@ SPDX-License-Identifier: MIT
     <div class="map-container">
         <div v-if="battleStore.battleOptions.map" class="map" :style="aspectRatioDrivenStyle">
             <img loading="lazy" :src="mapTextureUrl" />
-            <div v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes" class="boxes">
+            <!--
+            When the active preset has polygon-shaped startboxes (3+ vertex
+            ring), render a read-only SVG overlay only — the rect-div drag
+            handles are suppressed. The user "breaks free" into custom rect
+            edit mode by picking a different preset in the map options modal.
+            This matches the BYAR-Chobby#1184 behaviour reviewers approved.
+            For pure-rectangle presets (or custom mode), the existing rect
+            divs render with full drag/resize affordance unchanged.
+            -->
+            <div
+                v-if="battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes && boxes && !polygonPresetActive"
+                class="boxes"
+            >
                 <MapBattlePreviewStartBox v-for="(box, i) in boxes" v-startBox="box" :key="`box${i}`" :id="i" :box="box" />
             </div>
+            <svg
+                v-if="
+                    battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes &&
+                    polygonPresetActive &&
+                    polygonOverlays.length > 0
+                "
+                class="polygon-overlay"
+                viewBox="0 0 200 200"
+                preserveAspectRatio="none"
+            >
+                <path
+                    v-for="shape in polygonOverlays"
+                    :key="`poly${shape.index}`"
+                    :d="shape.path"
+                    fill="rgba(255, 255, 255, 0.08)"
+                    stroke="rgba(255, 255, 255, 0.9)"
+                    stroke-width="0.6"
+                    vector-effect="non-scaling-stroke"
+                />
+            </svg>
             <div
                 v-if="battleStore.battleOptions.mapOptions.startPosType in [StartPosType.Fixed, StartPosType.Random]"
                 class="start-positions"
@@ -56,6 +88,7 @@ import { StartBox } from "tachyon-protocol/types";
 import { computed, defineComponent, ref, watch } from "vue";
 import MapBattlePreviewStartBox from "@renderer/components/maps/MapBattlePreviewStartBox.vue";
 import defaultMiniMap from "/src/renderer/assets/images/default-minimap.png?url";
+import { isPolygonShape, tessellateRing } from "@renderer/utils/spline-tessellation";
 
 defineComponent({
     directives: {
@@ -88,6 +121,41 @@ watch(
 );
 
 const boxes = computed<StartBox[]>(() => battleActions.getCurrentStartBoxes());
+
+// Active preset is "polygon mode" when the currently-selected map preset
+// (startBoxesIndex) contains at least one 3+ vertex ring. In that mode, the
+// rect divs are hidden and only the SVG overlay renders — no drag/resize
+// affordance, since the polygon shape is intrinsic to the map and not
+// user-editable from the lobby. Switching to a custom preset clears
+// startBoxesIndex and turns this off.
+const polygonPresetActive = computed<boolean>(() => {
+    const startBoxesIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
+    if (startBoxesIndex === undefined) return false;
+    const set = battleStore.battleOptions.map?.startboxesSet?.[startBoxesIndex];
+    if (!set) return false;
+    return set.startboxes.some((box) => isPolygonShape(box.poly));
+});
+
+// SVG `<path>` strings for the active polygon preset's startboxes. Reads
+// directly from startboxesSet (rather than the rect-flattened `boxes`
+// computed above) so the polygon vertex data — including any per-anchor
+// Catmull-Rom strength — is preserved through the render. The path uses
+// the [0, 200] coordinate space directly via the parent SVG's viewBox.
+const polygonOverlays = computed<{ index: number; path: string }[]>(() => {
+    const startBoxesIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
+    if (startBoxesIndex === undefined) return [];
+    const set = battleStore.battleOptions.map?.startboxesSet?.[startBoxesIndex];
+    if (!set) return [];
+    const out: { index: number; path: string }[] = [];
+    set.startboxes.forEach((box, index) => {
+        if (!isPolygonShape(box.poly)) return;
+        const tess = tessellateRing(box.poly);
+        if (tess.length === 0) return;
+        const path = `M ${tess.map((p) => `${p.x} ${p.y}`).join(" L ")} Z`;
+        out.push({ index, path });
+    });
+    return out;
+});
 
 const aspectRatioDrivenStyle = computed(() => {
     if (!battleStore.battleOptions.map?.mapWidth || !battleStore.battleOptions.map?.mapHeight) {
@@ -142,6 +210,15 @@ const rgbColors = [
     position: absolute;
     width: 100%;
     height: 100%;
+}
+
+.polygon-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
 }
 
 .start-positions {

--- a/src/renderer/utils/spline-tessellation.ts
+++ b/src/renderer/utils/spline-tessellation.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+/**
+ * Catmull-Rom spline tessellation for startbox anchor rings.
+ *
+ * 1:1 port of:
+ *   - bar-game/common/lib_spline.lua (game-side tessellator)
+ *   - bar-chobby/LuaMenu/configs/gameConfig/byar/lib_spline.lua (Chobby preview)
+ *   - rowy/src/components/MapStartbox.tsx (editor preview)
+ *
+ * Identical inputs produce vertex-identical output across all four consumers,
+ * so the lobby preview, the Chobby preview, and the in-game render of the same
+ * startbox can never visually disagree.
+ */
+
+export interface AnchorPoint {
+    x: number;
+    y: number;
+    /** Optional strength in [0, 1]. 0 (or omitted) is a sharp polygon corner. */
+    strength?: number;
+}
+
+export interface TessellatedPoint {
+    x: number;
+    y: number;
+}
+
+const DEFAULT_SEGMENTS = 12;
+
+function clamp01(v: number): number {
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+}
+
+/**
+ * Sample a Catmull-Rom curve segment between p1 and p2 (with neighbours p0, p3),
+ * blended toward the linear interpolation by `tension` in [0, 1].
+ * tension == 0 returns the exact linear interpolation between p1 and p2.
+ * tension == 1 returns the full uniform Catmull-Rom sample.
+ * Anchor points lie on the curve regardless of tension because at t=0 and t=1
+ * both linear and Catmull-Rom outputs coincide with p1 and p2.
+ */
+function sampleSegment(
+    p0: AnchorPoint,
+    p1: AnchorPoint,
+    p2: AnchorPoint,
+    p3: AnchorPoint,
+    t: number,
+    tension: number
+): TessellatedPoint {
+    const lx = p1.x + (p2.x - p1.x) * t;
+    const ly = p1.y + (p2.y - p1.y) * t;
+    if (tension <= 0) return { x: lx, y: ly };
+
+    const t2 = t * t;
+    const t3 = t2 * t;
+    const crX =
+        0.5 *
+        (2 * p1.x +
+            (-p0.x + p2.x) * t +
+            (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 +
+            (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
+    const crY =
+        0.5 *
+        (2 * p1.y +
+            (-p0.y + p2.y) * t +
+            (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 +
+            (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
+
+    if (tension >= 1) return { x: crX, y: crY };
+    return {
+        x: lx + (crX - lx) * tension,
+        y: ly + (crY - ly) * tension,
+    };
+}
+
+/**
+ * Tessellate a closed ring of anchor points into a dense polygon. Anchors
+ * without explicit strength are treated as sharp corners (strength 0); plain
+ * polygons emerge with vertex-identical output (no extra vertices added).
+ *
+ * @param anchors closed ring of anchor points (at least 2)
+ * @param segments subdivisions per curved edge (default 12). Production
+ *   callers can omit this and accept the default; tests can supply a smaller
+ *   value to keep generated data compact.
+ */
+export function tessellateRing(anchors: AnchorPoint[], segments = DEFAULT_SEGMENTS): TessellatedPoint[] {
+    const n = anchors.length;
+    if (n < 2) return anchors.map((p) => ({ x: p.x, y: p.y }));
+    const seg = Math.max(1, segments);
+
+    const out: TessellatedPoint[] = [];
+    for (let i = 0; i < n; i++) {
+        const iPrev = (i - 1 + n) % n;
+        const iNext = (i + 1) % n;
+        const iNext2 = (iNext + 1) % n;
+        const p0 = anchors[iPrev];
+        const p1 = anchors[i];
+        const p2 = anchors[iNext];
+        const p3 = anchors[iNext2];
+
+        const s1 = clamp01(p1.strength ?? 0);
+        const s2 = clamp01(p2.strength ?? 0);
+        const edgeTension = clamp01((s1 + s2) * 0.5);
+
+        out.push({ x: p1.x, y: p1.y });
+        if (edgeTension > 0 && n >= 3) {
+            for (let k = 1; k < seg; k++) {
+                out.push(sampleSegment(p0, p1, p2, p3, k / seg, edgeTension));
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * Decide whether a poly should be drawn as a polygon outline (3+ points) or
+ * left to the existing rectangle renderer (2 points). Used by the lobby
+ * preview to branch between the rect-div and the SVG polygon overlay.
+ */
+export function isPolygonShape(poly: { x: number; y: number }[]): boolean {
+    return poly.length > 2;
+}

--- a/src/renderer/utils/spline-tessellation.ts
+++ b/src/renderer/utils/spline-tessellation.ts
@@ -43,32 +43,15 @@ function clamp01(v: number): number {
  * Anchor points lie on the curve regardless of tension because at t=0 and t=1
  * both linear and Catmull-Rom outputs coincide with p1 and p2.
  */
-function sampleSegment(
-    p0: AnchorPoint,
-    p1: AnchorPoint,
-    p2: AnchorPoint,
-    p3: AnchorPoint,
-    t: number,
-    tension: number
-): TessellatedPoint {
+function sampleSegment(p0: AnchorPoint, p1: AnchorPoint, p2: AnchorPoint, p3: AnchorPoint, t: number, tension: number): TessellatedPoint {
     const lx = p1.x + (p2.x - p1.x) * t;
     const ly = p1.y + (p2.y - p1.y) * t;
     if (tension <= 0) return { x: lx, y: ly };
 
     const t2 = t * t;
     const t3 = t2 * t;
-    const crX =
-        0.5 *
-        (2 * p1.x +
-            (-p0.x + p2.x) * t +
-            (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 +
-            (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
-    const crY =
-        0.5 *
-        (2 * p1.y +
-            (-p0.y + p2.y) * t +
-            (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 +
-            (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
+    const crX = 0.5 * (2 * p1.x + (-p0.x + p2.x) * t + (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 + (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
+    const crY = 0.5 * (2 * p1.y + (-p0.y + p2.y) * t + (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 + (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
 
     if (tension >= 1) return { x: crX, y: crY };
     return {

--- a/src/renderer/utils/start-boxes.ts
+++ b/src/renderer/utils/start-boxes.ts
@@ -59,9 +59,19 @@ export function getBoxes(orientation: StartBoxOrientation, percent = 30): StartB
     }
 }
 
+/**
+ * Converts a startbox poly to the Tachyon `StartBox` rectangle format.
+ * Accepts either:
+ *   - 2 points: legacy axis-aligned rectangle (top-left, bottom-right corners)
+ *   - 3+ points: closed polygon ring (a Catmull-Rom spline if any anchor has
+ *     `strength`); the bounding box of the vertices is returned, since the
+ *     Tachyon protocol and engine start script are rectangle-only.
+ * The original polygon shape is preserved upstream and rendered as an SVG
+ * overlay on the map preview.
+ */
 export function spadsBoxToStartBox(points: StartBoxPoly[]) {
-    if (points.length !== 2) {
-        throw new Error("spadsBoxToStartBox expects exactly 2 points");
+    if (points.length < 2) {
+        throw new Error("spadsBoxToStartBox needs at least 2 points");
     }
 
     const xs = points.map((point) => point.x);


### PR DESCRIPTION
### Work done

Adds polygon and Catmull-Rom spline startbox rendering to the battle map preview. Maps that ship 3+ vertex polygons in their `startboxesSet` (via the maps-metadata schema PR) now render their actual region shape as an SVG overlay instead of collapsing to a bounding-box rectangle.

Reworks the previously-closed [#570](https://github.com/beyond-all-reason/bar-lobby/pull/570) from `master`. That earlier attempt loaded polygon configs directly from `.sd7` archives via Fengari Lua evaluation.

- New `src/renderer/utils/spline-tessellation.ts` — TypeScript port of `common/lib_spline.lua` (game-side), `LuaMenu/configs/gameConfig/byar/lib_spline.lua` (Chobby), and the in-line tessellator in the Rowy editor. Identical inputs produce vertex-identical output across all four consumers, so the lobby preview, the Chobby preview, and the in-game render of the same startbox can never visually disagree.
- `src/main/content/maps/map-metadata.ts` — added optional `strength?: number` to `StartBoxPoly` for spline anchors. Mirrors the schema in maps-metadata#615.
- `src/main/content/maps/box-utils.ts` — `spadsPointsToLTRBPercent` accepts N-point polygons (computes bounding box across all vertices). Removed dead `pointsToXYWH` helper that had been unused since introduction in `92f0f66`.
- `src/renderer/utils/start-boxes.ts` — `spadsBoxToStartBox` accepts N-point polygons; the existing min/max math already handled N points correctly, only the length-2 throw blocked it.
- `src/renderer/components/maps/MapBattlePreview.vue` — SVG polygon overlay with `pointer-events: none`, `viewBox="0 0 200 200"` matching the schema's coordinate space. When the active preset has any polygon-shaped startboxes, the rect-div drag handles are suppressed (read-only) — matching the BYAR-Chobby#1184 behaviour AntlerForce approved. Switching to a custom preset re-enables drag/resize.

#### Setup
Until [beyond-all-reason/maps-metadata#615](https://github.com/beyond-all-reason/maps-metadata/pull/615) merges and Rowy starts populating polygon vertex data, the only way to drive this end-to-end through the live data pipeline is via a custom build of maps-metadata that emits a `lobby_maps.validated.json` with 3+ point polys. Once that PR merges, polygon and spline data will flow through automatically.

For local testing today, manually edit a map's entry in your local `lobby_maps.validated.json` cache to insert 3+ point polys (with optional `strength` fields).

### Related PRs
- Core Game - https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513
- Chobby Lobby - https://github.com/beyond-all-reason/BYAR-Chobby/pull/1184
- Rowy Fork - https://github.com/p2004a/rowy/pull/1
- Maps-Metadata - https://github.com/beyond-all-reason/maps-metadata/pull/615

### AI / LLM usage statement
Assisted by GitHub Copilot (Claude Opus 4.7). Used for PR authoring, refactoring, and test scaffolding.
