### PR TITLE
Implemented Taskbar/Dock progress bar

### DIFF
--- a/src/main/content/auto-updater.ts
+++ b/src/main/content/auto-updater.ts
@@ -60,6 +60,8 @@ export class AutoUpdaterAPI extends Downloader {
     public async downloadUpdate(): Promise<void> {
         if (!this.intialized) return;
         if (this.updateInfo == undefined) throw Error("Tried to download unavailable update");
+        // Note, there is no this.downloadStarted but downloadProgress handles it well enough
+        // If we ever need to track that it actually started, we would add that here.
         return await new Promise<void>((resolve) => {
             autoUpdater.on("download-progress", (progressInfo) => {
                 this.downloadProgress({
@@ -72,11 +74,27 @@ export class AutoUpdaterAPI extends Downloader {
             });
 
             autoUpdater.on("update-downloaded", (info) => {
+                // 'info' does not have download details, so we just falsify the values since it's complete anyway.
+                this.downloadComplete({
+                    type: "update",
+                    name: this.updateInfo?.version ?? "unknown",
+                    currentBytes: 1,
+                    totalBytes: 1,
+                    progress: 1,
+                });
                 this.updateInfo = info;
                 resolve();
             });
 
             autoUpdater.on("error", (error, message) => {
+                // As above, 'info' does not have download details, so we just falsify the values since it's stopped already
+                this.downloadFailed({
+                    type: "update",
+                    name: this.updateInfo?.version ?? "unknown",
+                    currentBytes: 0,
+                    totalBytes: 0,
+                    progress: 0,
+                });
                 log.error(error, `Error downloading update. ${message}`);
                 resolve();
             });

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -10,6 +10,7 @@ import icon from "@main/resources/icon.png";
 import { purgeLogFiles } from "@main/services/log.service";
 import { typedWebContents, ipcMain } from "@main/typed-ipc";
 import { gameAPI } from "@main/game/game";
+import downloadsService from "@main/services/downloads.service";
 
 const ZOOM_FACTOR_BASELINE_HEIGHT = 1080;
 
@@ -128,6 +129,9 @@ export function createWindow() {
     ipcMain.handle("mainWindow:resized", () => {
         updateZoom();
     });
+
+    // Get download progress updates to update the dock/taskbar
+    downloadsService.registerProgressHandler(mainWindow);
 
     /////////////////////////////////////////////
     // Subscribe to game events

--- a/src/main/services/downloads.service.ts
+++ b/src/main/services/downloads.service.ts
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: MIT
 
 import { autoUpdaterAPI } from "@main/content/auto-updater";
+import { DownloadInfo } from "@main/content/downloads";
 import { engineContentAPI } from "@main/content/engine/engine-content";
 import { gameContentAPI } from "@main/content/game/game-content";
 import { mapContentAPI } from "@main/content/maps/map-content";
 import { BarIpcWebContents } from "@main/typed-ipc";
+
+const downloads: Map<string, DownloadInfo> = new Map();
 
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     engineContentAPI.onDownloadStart.add((downloadInfo) => {
@@ -59,8 +62,96 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     });
 }
 
+function registerProgressHandler(mainWindow: Electron.CrossProcessExports.BrowserWindow) {
+    engineContentAPI.onDownloadStart.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    engineContentAPI.onDownloadComplete.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+    engineContentAPI.onDownloadProgress.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    engineContentAPI.onDownloadFail.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+
+    gameContentAPI.onDownloadStart.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    gameContentAPI.onDownloadComplete.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+    gameContentAPI.onDownloadProgress.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    gameContentAPI.onDownloadFail.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+
+    mapContentAPI.onDownloadStart.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    mapContentAPI.onDownloadComplete.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+    mapContentAPI.onDownloadProgress.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    mapContentAPI.onDownloadFail.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+
+    autoUpdaterAPI.onDownloadStart.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    autoUpdaterAPI.onDownloadComplete.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+    autoUpdaterAPI.onDownloadProgress.add((downloadInfo) => {
+        downloads.set(downloadInfo.name, downloadInfo);
+        updateProgressBar(mainWindow);
+    });
+    autoUpdaterAPI.onDownloadFail.add((downloadInfo) => {
+        downloads.delete(downloadInfo.name);
+        updateProgressBar(mainWindow);
+    });
+}
+
+function updateProgressBar(mainWindow: Electron.CrossProcessExports.BrowserWindow) {
+    // If we have no active downloads, clear the progress bar.
+    if (downloads.size == 0) {
+        mainWindow.setProgressBar(-1);
+        return;
+    }
+    // Get the total progress of all downloads and the number of downloads.
+    let totalProgress = 0;
+    let downloadCount = 0;
+    downloads.forEach((d) => {
+        totalProgress += d.progress;
+        downloadCount += 1;
+    });
+    // Set the progress percent to the average progress of all downloads.
+    mainWindow.setProgressBar(totalProgress / downloadCount);
+}
+
 const downloadsService = {
     registerIpcHandlers,
+    registerProgressHandler,
 };
 
 export default downloadsService;

--- a/src/main/services/downloads.service.ts
+++ b/src/main/services/downloads.service.ts
@@ -9,8 +9,6 @@ import { gameContentAPI } from "@main/content/game/game-content";
 import { mapContentAPI } from "@main/content/maps/map-content";
 import { BarIpcWebContents } from "@main/typed-ipc";
 
-const downloads: Map<string, DownloadInfo> = new Map();
-
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     engineContentAPI.onDownloadStart.add((downloadInfo) => {
         webContents.send("downloads:engine:start", downloadInfo);
@@ -62,73 +60,27 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     });
 }
 
+const downloads: Map<string, DownloadInfo> = new Map();
+
 function registerProgressHandler(mainWindow: Electron.CrossProcessExports.BrowserWindow) {
-    engineContentAPI.onDownloadStart.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    engineContentAPI.onDownloadComplete.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-    engineContentAPI.onDownloadProgress.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    engineContentAPI.onDownloadFail.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-
-    gameContentAPI.onDownloadStart.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    gameContentAPI.onDownloadComplete.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-    gameContentAPI.onDownloadProgress.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    gameContentAPI.onDownloadFail.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-
-    mapContentAPI.onDownloadStart.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    mapContentAPI.onDownloadComplete.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-    mapContentAPI.onDownloadProgress.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    mapContentAPI.onDownloadFail.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-
-    autoUpdaterAPI.onDownloadStart.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    autoUpdaterAPI.onDownloadComplete.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
-    });
-    autoUpdaterAPI.onDownloadProgress.add((downloadInfo) => {
-        downloads.set(downloadInfo.name, downloadInfo);
-        updateProgressBar(mainWindow);
-    });
-    autoUpdaterAPI.onDownloadFail.add((downloadInfo) => {
-        downloads.delete(downloadInfo.name);
-        updateProgressBar(mainWindow);
+    const apiList = [engineContentAPI, gameContentAPI, mapContentAPI, autoUpdaterAPI];
+    apiList.forEach((api) => {
+        api.onDownloadStart.add((downloadInfo) => {
+            downloads.set(downloadInfo.name, downloadInfo);
+            updateProgressBar(mainWindow);
+        });
+        api.onDownloadComplete.add((downloadInfo) => {
+            downloads.delete(downloadInfo.name);
+            updateProgressBar(mainWindow);
+        });
+        api.onDownloadProgress.add((downloadInfo) => {
+            downloads.set(downloadInfo.name, downloadInfo);
+            updateProgressBar(mainWindow);
+        });
+        api.onDownloadFail.add((downloadInfo) => {
+            downloads.delete(downloadInfo.name);
+            updateProgressBar(mainWindow);
+        });
     });
 }
 
@@ -140,13 +92,11 @@ function updateProgressBar(mainWindow: Electron.CrossProcessExports.BrowserWindo
     }
     // Get the total progress of all downloads and the number of downloads.
     let totalProgress = 0;
-    let downloadCount = 0;
     downloads.forEach((d) => {
         totalProgress += d.progress;
-        downloadCount += 1;
     });
     // Set the progress percent to the average progress of all downloads.
-    mainWindow.setProgressBar(totalProgress / downloadCount);
+    mainWindow.setProgressBar(totalProgress / downloads.size);
 }
 
 const downloadsService = {


### PR DESCRIPTION
Closes #131 

Electron permits updating a "progress bar" attached to the main icon in the taskbar or dock. This implements the use of that feature for all downloads.

Tested and working on Windows 11. I don't have immediate access to a Linux machine that can run this so some confirmation there would be appreciated. Note comments in the [Electron documentation](https://www.electronjs.org/docs/latest/api/browser-window#winsetprogressbarprogress-options).

> On Linux platform, only supports Unity desktop environment, you need to specify the *.desktop file name to desktopName field in package.json. By default, it will assume {app.name}.desktop.

### AI / LLM usage statement:
`qwen2.5-coder:1.5b-base` was used as an Autocomplete/Inline Suggestions aid. All suggestions were reviewed and approved individually.