### PR TITLE
Send polygon startboxes to the game

### DIFF
--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -31,7 +31,7 @@ function encodeStartboxesSet(set: Startbox[]): string {
 // Lobby-owned custom areas: a single arrangement the game prefers over the set
 // (matchOverride matches when startboxes.length == numTeams). Boxes are 0-1 rects;
 // a 2-point poly is read as opposite corners on the 0-200 grid.
-function encodeStartboxOverride(boxes: StartBox[], playerCountMax: number): string {
+function encodeStartboxOverride(boxes: StartBox[]): string {
     return encodeModoptionValue({
         startboxes: boxes.map((b) => ({
             poly: [
@@ -39,7 +39,6 @@ function encodeStartboxOverride(boxes: StartBox[], playerCountMax: number): stri
                 { x: Math.round(b.right * 200), y: Math.round(b.bottom * 200) },
             ],
         })),
-        maxPlayersPerStartbox: Math.max(1, Math.round(playerCountMax / boxes.length)),
     });
 }
 
@@ -193,7 +192,7 @@ class StartScriptConverter {
             if (mapOptions.startBoxesIndex != undefined && battle.battleOptions.map.startboxesSet.length > 0) {
                 modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(battle.battleOptions.map.startboxesSet);
             } else if (mapOptions.customStartBoxes && mapOptions.customStartBoxes.length > 0) {
-                modoptions.mapmetadata_startbox_override = encodeStartboxOverride(mapOptions.customStartBoxes, battle.battleOptions.map.playerCountMax);
+                modoptions.mapmetadata_startbox_override = encodeStartboxOverride(mapOptions.customStartBoxes);
             }
         }
 

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import zlib from "node:zlib";
+import zlib from "zlib";
 
 import { spadsPointsToLTRBPercent } from "@main/content/maps/box-utils";
 import { Startbox } from "@main/content/maps/map-metadata";

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -4,22 +4,43 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import zlib from "zlib";
+import { StartBox } from "tachyon-protocol/types";
 
 import { spadsPointsToLTRBPercent } from "@main/content/maps/box-utils";
 import { Startbox } from "@main/content/maps/map-metadata";
 import { BattleWithMetadata, isPlayer, StartPosType } from "@main/game/battle/battle-types";
 import { AllyTeam, Bot, Game, Player, Team } from "@main/model/start-script";
 
-// JSON -> zlib deflate -> base64url, padding stripped. Mirrors the maps-metadata
-// gen_map_modoptions encoder and the game-side decoder; the modoption value
-// pattern (^[a-zA-Z0-9_.-]+$) forbids '=' padding. Keyed by team count so the
-// game resolves set[numTeams] back to the arrangement the lobby selected.
+// JSON -> zlib deflate -> base64url, padding stripped. Matches the maps-metadata
+// modoption transport and the game-side decoder; the modoption value pattern
+// (^[a-zA-Z0-9_.-]+$) forbids '=' padding.
+function encodeModoptionValue(value: unknown): string {
+    return zlib.deflateSync(JSON.stringify(value)).toString("base64url").replace(/=+$/, "");
+}
+
+// Server-owned default: the whole set keyed by team count, so the game resolves
+// set[numTeams] back to the arrangement the lobby selected.
 function encodeStartboxesSet(set: Startbox[]): string {
     const byTeamCount: Record<string, Startbox> = {};
     for (const arrangement of set) {
         byTeamCount[String(arrangement.startboxes.length)] = arrangement;
     }
-    return zlib.deflateSync(JSON.stringify(byTeamCount)).toString("base64url").replace(/=+$/, "");
+    return encodeModoptionValue(byTeamCount);
+}
+
+// Lobby-owned custom areas: a single arrangement the game prefers over the set
+// (matchOverride matches when startboxes.length == numTeams). Boxes are 0-1 rects;
+// a 2-point poly is read as opposite corners on the 0-200 grid.
+function encodeStartboxOverride(boxes: StartBox[], playerCountMax: number): string {
+    return encodeModoptionValue({
+        startboxes: boxes.map((b) => ({
+            poly: [
+                { x: Math.round(b.left * 200), y: Math.round(b.top * 200) },
+                { x: Math.round(b.right * 200), y: Math.round(b.bottom * 200) },
+            ],
+        })),
+        maxPlayersPerStartbox: Math.max(1, Math.round(playerCountMax / boxes.length)),
+    });
 }
 
 /**
@@ -163,11 +184,17 @@ class StartScriptConverter {
 
         const modoptions: Record<string, any> = { ...battle.battleOptions.gameMode.options };
 
-        // Engine startboxes are rectangles only, so the polygon shape rides to the
-        // game as a modoption. Only for a selected preset - custom drag-edited boxes
-        // stay engine-native rectangles and need no modoption.
-        if (battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes && battle.battleOptions.mapOptions.startBoxesIndex != undefined && battle.battleOptions.map.startboxesSet.length > 0) {
-            modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(battle.battleOptions.map.startboxesSet);
+        // Engine startboxes are rectangles only, so start areas ride to the game as
+        // modoptions. A selected preset becomes the set; custom drag-edited boxes
+        // become the override, which the game prefers over the set. The engine-native
+        // startrects set above remain a baseline for game builds without the decoder.
+        const mapOptions = battle.battleOptions.mapOptions;
+        if (mapOptions.startPosType === StartPosType.Boxes) {
+            if (mapOptions.startBoxesIndex != undefined && battle.battleOptions.map.startboxesSet.length > 0) {
+                modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(battle.battleOptions.map.startboxesSet);
+            } else if (mapOptions.customStartBoxes && mapOptions.customStartBoxes.length > 0) {
+                modoptions.mapmetadata_startbox_override = encodeStartboxOverride(mapOptions.customStartBoxes, battle.battleOptions.map.playerCountMax);
+            }
         }
 
         return {

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -3,9 +3,24 @@
 // SPDX-License-Identifier: MIT
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import zlib from "node:zlib";
+
 import { spadsPointsToLTRBPercent } from "@main/content/maps/box-utils";
+import { Startbox } from "@main/content/maps/map-metadata";
 import { BattleWithMetadata, isPlayer, StartPosType } from "@main/game/battle/battle-types";
 import { AllyTeam, Bot, Game, Player, Team } from "@main/model/start-script";
+
+// JSON -> zlib deflate -> base64url, padding stripped. Mirrors the maps-metadata
+// gen_map_modoptions encoder and the game-side decoder; the modoption value
+// pattern (^[a-zA-Z0-9_.-]+$) forbids '=' padding. Keyed by team count so the
+// game resolves set[numTeams] back to the arrangement the lobby selected.
+function encodeStartboxesSet(set: Startbox[]): string {
+    const byTeamCount: Record<string, Startbox> = {};
+    for (const arrangement of set) {
+        byTeamCount[String(arrangement.startboxes.length)] = arrangement;
+    }
+    return zlib.deflateSync(JSON.stringify(byTeamCount)).toString("base64url").replace(/=+$/, "");
+}
 
 /**
  * https://springrts.com/wiki/Script.txt
@@ -146,10 +161,23 @@ class StartScriptConverter {
         if (!battle.battleOptions.map) throw new Error("failed to access battle options map");
         if (!battle.me) throw new Error("failed to access current player");
 
+        const modoptions: Record<string, any> = { ...battle.battleOptions.gameMode.options };
+
+        // Engine startboxes are rectangles only, so the polygon shape rides to the
+        // game as a modoption. Only for a selected preset - custom drag-edited boxes
+        // stay engine-native rectangles and need no modoption.
+        if (
+            battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes &&
+            battle.battleOptions.mapOptions.startBoxesIndex != undefined &&
+            battle.battleOptions.map.startboxesSet.length > 0
+        ) {
+            modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(battle.battleOptions.map.startboxesSet);
+        }
+
         return {
             gametype: battle.battleOptions.gameVersion,
             mapname: battle.battleOptions.map.springName,
-            modoptions: battle.battleOptions.gameMode.options,
+            modoptions,
             // mapoptions: battle.battleOptions.???,
             ishost: 1,
             myplayername: battle.me.user.username,

--- a/src/main/utils/start-script-converter.ts
+++ b/src/main/utils/start-script-converter.ts
@@ -166,11 +166,7 @@ class StartScriptConverter {
         // Engine startboxes are rectangles only, so the polygon shape rides to the
         // game as a modoption. Only for a selected preset - custom drag-edited boxes
         // stay engine-native rectangles and need no modoption.
-        if (
-            battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes &&
-            battle.battleOptions.mapOptions.startBoxesIndex != undefined &&
-            battle.battleOptions.map.startboxesSet.length > 0
-        ) {
+        if (battle.battleOptions.mapOptions.startPosType === StartPosType.Boxes && battle.battleOptions.mapOptions.startBoxesIndex != undefined && battle.battleOptions.map.startboxesSet.length > 0) {
             modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(battle.battleOptions.map.startboxesSet);
         }
 

--- a/src/renderer/utils/spline-tessellation.ts
+++ b/src/renderer/utils/spline-tessellation.ts
@@ -35,23 +35,53 @@ function clamp01(v: number): number {
     return v;
 }
 
+/** Centripetal knot spacing: |delta|^0.5 (alpha = 0.5). */
+function knotDelta(a: { x: number; y: number }, b: { x: number; y: number }): number {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    return Math.pow(dx * dx + dy * dy, 0.25);
+}
+
+/** Barry-Goldman lerp of a->b over knot span [ta, tb], evaluated at tt. */
+function bgLerp(tt: number, a: { x: number; y: number }, b: { x: number; y: number }, ta: number, tb: number): { x: number; y: number } {
+    const w = (tb - tt) / (tb - ta);
+    return { x: w * a.x + (1 - w) * b.x, y: w * a.y + (1 - w) * b.y };
+}
+
 /**
- * Sample a Catmull-Rom curve segment between p1 and p2 (with neighbours p0, p3),
- * blended toward the linear interpolation by `tension` in [0, 1].
- * tension == 0 returns the exact linear interpolation between p1 and p2.
- * tension == 1 returns the full uniform Catmull-Rom sample.
- * Anchor points lie on the curve regardless of tension because at t=0 and t=1
- * both linear and Catmull-Rom outputs coincide with p1 and p2.
+ * Sample a centripetal Catmull-Rom curve segment between p1 and p2 (neighbours
+ * p0, p3), blended toward the straight chord by `tension` in [0, 1].
+ * Centripetal parameterization (alpha = 0.5) avoids the cusps/self-intersections
+ * (the "curly-q" overshoot) that uniform Catmull-Rom produces at sharp corners.
+ * tension == 0 returns the exact linear interpolation; tension == 1 the full
+ * centripetal sample. Anchors lie on the curve (t=0 -> p1, t=1 -> p2).
  */
 function sampleSegment(p0: AnchorPoint, p1: AnchorPoint, p2: AnchorPoint, p3: AnchorPoint, t: number, tension: number): TessellatedPoint {
     const lx = p1.x + (p2.x - p1.x) * t;
     const ly = p1.y + (p2.y - p1.y) * t;
     if (tension <= 0) return { x: lx, y: ly };
 
-    const t2 = t * t;
-    const t3 = t2 * t;
-    const crX = 0.5 * (2 * p1.x + (-p0.x + p2.x) * t + (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 + (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
-    const crY = 0.5 * (2 * p1.y + (-p0.y + p2.y) * t + (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 + (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
+    const t0 = 0;
+    const t1 = t0 + knotDelta(p0, p1);
+    const t2 = t1 + knotDelta(p1, p2);
+    const t3 = t2 + knotDelta(p2, p3);
+
+    let crX: number;
+    let crY: number;
+    if (t2 - t1 <= 1e-9) {
+        crX = p1.x;
+        crY = p1.y;
+    } else {
+        const tt = t1 + (t2 - t1) * t;
+        const A1 = t1 - t0 > 1e-9 ? bgLerp(tt, p0, p1, t0, t1) : { x: p1.x, y: p1.y };
+        const A2 = bgLerp(tt, p1, p2, t1, t2);
+        const A3 = t3 - t2 > 1e-9 ? bgLerp(tt, p2, p3, t2, t3) : { x: p2.x, y: p2.y };
+        const B1 = bgLerp(tt, A1, A2, t0, t2);
+        const B2 = bgLerp(tt, A2, A3, t1, t3);
+        const C = bgLerp(tt, B1, B2, t1, t2);
+        crX = C.x;
+        crY = C.y;
+    }
 
     if (tension >= 1) return { x: crX, y: crY };
     return {

--- a/tests/unit/main/start-script-converter.spec.ts
+++ b/tests/unit/main/start-script-converter.spec.ts
@@ -8,6 +8,11 @@ import { describe, expect, it } from "vitest";
 import { BattleWithMetadata, GameModeID, StartPosType } from "@main/game/battle/battle-types";
 import { startScriptConverter } from "@main/utils/start-script-converter";
 
+type Arrangement = {
+    startboxes: { poly: { x: number; y: number; strength?: number }[] }[];
+    maxPlayersPerStartbox?: number;
+};
+
 const polygonSet = [
     {
         maxPlayersPerStartbox: 8,
@@ -39,32 +44,36 @@ function twoTeamBattle(mapOptions: Record<string, unknown>): BattleWithMetadata 
         battleOptions: {
             gameVersion: "test",
             gameMode: { id: GameModeID.CLASSIC, label: "Classic", options: {} },
-            map: { springName: "Test Map", startboxesSet: polygonSet },
+            map: { springName: "Test Map", startboxesSet: polygonSet, playerCountMax: 16 },
             mapOptions,
             restrictions: [],
         },
     } as unknown as BattleWithMetadata;
 }
 
-function extractSet(script: string): Record<string, { startboxes: { poly: { x: number; y: number; strength?: number }[] }[] }> {
-    const match = script.match(/mapmetadata_startboxes_set\s*=\s*([^;\s}]+)/);
-    if (!match) throw new Error("modoption not found in start script");
+function decodeModoption(script: string, pattern: RegExp): unknown {
+    const match = script.match(pattern);
+    if (!match) throw new Error(`modoption not found in start script: ${pattern}`);
     return JSON.parse(zlib.inflateSync(Buffer.from(match[1], "base64url")).toString());
 }
 
-describe("start script polygon startbox modoption", () => {
+const SET = /mapmetadata_startboxes_set\s*=\s*([^;\s}]+)/;
+const OVERRIDE = /mapmetadata_startbox_override\s*=\s*([^;\s}]+)/;
+
+describe("start script polygon startbox modoptions", () => {
     it("injects the set keyed by team count when a preset is selected", () => {
         const script = startScriptConverter.generateScriptStr(twoTeamBattle({ startPosType: StartPosType.Boxes, startBoxesIndex: 0 }));
 
         expect(script).toContain("mapmetadata_startboxes_set");
+        expect(script).not.toContain("mapmetadata_startbox_override");
 
-        const set = extractSet(script);
+        const set = decodeModoption(script, SET) as Record<string, Arrangement>;
         expect(Object.keys(set)).toEqual(["2"]);
         expect(set["2"].startboxes).toHaveLength(2);
         expect(set["2"].startboxes[0].poly[2].strength).toBe(1);
     });
 
-    it("omits the modoption for custom drag-edited boxes", () => {
+    it("injects an override (not a set) for custom drag-edited boxes", () => {
         const script = startScriptConverter.generateScriptStr(
             twoTeamBattle({
                 startPosType: StartPosType.Boxes,
@@ -76,5 +85,15 @@ describe("start script polygon startbox modoption", () => {
         );
 
         expect(script).not.toContain("mapmetadata_startboxes_set");
+        expect(script).toContain("mapmetadata_startbox_override");
+
+        const override = decodeModoption(script, OVERRIDE) as Arrangement;
+        // single arrangement, not keyed by team count; matchOverride checks startboxes.length == numTeams
+        expect(override.startboxes).toHaveLength(2);
+        // a 2-point poly is opposite corners on the 0-200 grid
+        expect(override.startboxes[0].poly).toEqual([
+            { x: 0, y: 0 },
+            { x: 50, y: 200 },
+        ]);
     });
 });

--- a/tests/unit/main/start-script-converter.spec.ts
+++ b/tests/unit/main/start-script-converter.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/unit/main/start-script-converter.spec.ts
+++ b/tests/unit/main/start-script-converter.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import zlib from "zlib";
+import { describe, expect, it } from "vitest";
+
+import { BattleWithMetadata, GameModeID, StartPosType } from "@main/game/battle/battle-types";
+import { startScriptConverter } from "@main/utils/start-script-converter";
+
+const polygonSet = [
+    {
+        maxPlayersPerStartbox: 8,
+        startboxes: [
+            {
+                poly: [
+                    { x: 0, y: 0 },
+                    { x: 60, y: 0 },
+                    { x: 30, y: 60, strength: 1 },
+                ],
+            },
+            {
+                poly: [
+                    { x: 140, y: 200 },
+                    { x: 200, y: 200 },
+                    { x: 170, y: 140 },
+                ],
+            },
+        ],
+    },
+];
+
+function twoTeamBattle(mapOptions: Record<string, unknown>): BattleWithMetadata {
+    return {
+        isOnline: false,
+        spectators: [],
+        me: { id: 0, user: { username: "p1", userId: 1 } },
+        teams: [{ participants: [{ id: 0, user: { username: "p1", userId: 1 } }] }, { participants: [{ id: 1, user: { username: "p2", userId: 2 } }] }],
+        battleOptions: {
+            gameVersion: "test",
+            gameMode: { id: GameModeID.CLASSIC, label: "Classic", options: {} },
+            map: { springName: "Test Map", startboxesSet: polygonSet },
+            mapOptions,
+            restrictions: [],
+        },
+    } as unknown as BattleWithMetadata;
+}
+
+function extractSet(script: string): Record<string, { startboxes: { poly: { x: number; y: number; strength?: number }[] }[] }> {
+    const match = script.match(/mapmetadata_startboxes_set\s*=\s*([^;\s}]+)/);
+    if (!match) throw new Error("modoption not found in start script");
+    return JSON.parse(zlib.inflateSync(Buffer.from(match[1], "base64url")).toString());
+}
+
+describe("start script polygon startbox modoption", () => {
+    it("injects the set keyed by team count when a preset is selected", () => {
+        const script = startScriptConverter.generateScriptStr(twoTeamBattle({ startPosType: StartPosType.Boxes, startBoxesIndex: 0 }));
+
+        expect(script).toContain("mapmetadata_startboxes_set");
+
+        const set = extractSet(script);
+        expect(Object.keys(set)).toEqual(["2"]);
+        expect(set["2"].startboxes).toHaveLength(2);
+        expect(set["2"].startboxes[0].poly[2].strength).toBe(1);
+    });
+
+    it("omits the modoption for custom drag-edited boxes", () => {
+        const script = startScriptConverter.generateScriptStr(
+            twoTeamBattle({
+                startPosType: StartPosType.Boxes,
+                customStartBoxes: [
+                    { left: 0, top: 0, right: 0.25, bottom: 1 },
+                    { left: 0.75, top: 0, right: 1, bottom: 1 },
+                ],
+            })
+        );
+
+        expect(script).not.toContain("mapmetadata_startboxes_set");
+    });
+});


### PR DESCRIPTION
Picks up where #574 left off, which rendered polygon startboxes in the preview but still handed the game a plain bounding-box rectangle at launch, so an offline game never got the real shape. Now the offline start script sends the start areas as modoptions, the way the game PR settled on: a selected preset goes out as the set (`mapmetadata_startboxes_set`, the server-owned default), and custom drag-edited boxes go out as the override (`mapmetadata_startbox_override`, lobby-owned) which the game prefers over the set. So an offline game enforces the real shape, custom boxes aren't silently replaced by the map's default, and online games get the set from the server.

It also brings the preview's spline in line with the game and Chobby so the curves match exactly. The old math overshot at sharp corners and could draw a small curl the game never showed.

Related PRs:
- Core game: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513
- Chobby: https://github.com/beyond-all-reason/BYAR-Chobby/pull/1184
- Maps-metadata: https://github.com/beyond-all-reason/maps-metadata/pull/615
- Rowy fork: https://github.com/p2004a/rowy/pull/1
- Original bar-lobby PR (merged): https://github.com/beyond-all-reason/bar-lobby/pull/574

Assisted by Claude Code (Opus 4.8); all code reviewed and verified locally.
