### PR TITLE
Update 7zip-min.ts

### DIFF
--- a/vendor/7zip-min/7zip-min.ts
+++ b/vendor/7zip-min/7zip-min.ts
@@ -69,7 +69,7 @@ function run(bin, args, cb) {
     proc.on('error', function (err) {
         cb(err);
     });
-    proc.on('exit', function (code) {
+    proc.on('close', function (code) {
         if (code) {
             runError.message = `7-zip exited with code ${code}\n${output}`;
         }


### PR DESCRIPTION
Fixes #599 

Research of this issue revealed that there was a fix to 7zip-min that is not incorporated into our vendored version. See https://github.com/onikienko/7zip-min/pull/37 for relevant discussion. I have not been able to replicate the issue after having made this change.