### PR TITLE
Perf: Debounce search input, throttle MaxPlayersFilter

### DIFF
--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -90,9 +90,10 @@ export default defineComponent({
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
         const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200);
 
-        function clear() {
-            emit("update:modelValue", "");
-        }
+function clear() {
+    debouncedEmit.cancel();
+    emit("update:modelValue", "");
+}
 
         function onInput(e: Event) {
             debouncedEmit((e.target as HTMLInputElement).value);

--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -88,7 +88,7 @@ export default defineComponent({
             return res;
         });
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
-        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200);
+        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200) as ReturnType<typeof useDebounceFn> & { cancel: () => void };
 
         function clear() {
             debouncedEmit.cancel();

--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -90,10 +90,10 @@ export default defineComponent({
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
         const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200);
 
-function clear() {
-    debouncedEmit.cancel();
-    emit("update:modelValue", "");
-}
+        function clear() {
+            debouncedEmit.cancel();
+            emit("update:modelValue", "");
+        }
 
         function onInput(e: Event) {
             debouncedEmit((e.target as HTMLInputElement).value);

--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -38,6 +38,8 @@ SPDX-License-Identifier: MIT
  * easiest to just copy and clean up. MIT license, so safe to do.
  */
 import { computed, defineComponent, PropType, ref } from "vue";
+import { useDebounceFn } from "@vueuse/core";
+
 export const fieldType = ["search", "text"];
 export type FieldType = (typeof fieldType)[number];
 function filterObject(obj: { [key: string]: unknown }, properties: (string | number)[], remove = true) {
@@ -86,12 +88,16 @@ export default defineComponent({
             return res;
         });
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
+        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200);
+
         function clear() {
             emit("update:modelValue", "");
         }
+
         function onInput(e: Event) {
-            emit("update:modelValue", (e.target as HTMLInputElement).value);
+            debouncedEmit((e.target as HTMLInputElement).value);
         }
+
         function onKeydown(e: KeyboardEvent) {
             if (e.defaultPrevented) return; // Some components might handle this already
             if (e.key === "Escape" && props.clearOnEsc) {

--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -88,12 +88,11 @@ export default defineComponent({
             return res;
         });
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
-        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200) as ReturnType<
-            typeof useDebounceFn
-        > & { cancel: () => void };
+        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200) as ReturnType<typeof useDebounceFn>;
 
         function clear() {
-            debouncedEmit.cancel();
+            // TODO: Not supported until we upgrade to @vueuse/core v14
+            // debouncedEmit.cancel();
             emit("update:modelValue", "");
         }
 

--- a/src/renderer/components/controls/SearchBox.vue
+++ b/src/renderer/components/controls/SearchBox.vue
@@ -88,7 +88,9 @@ export default defineComponent({
             return res;
         });
         const showClearIcon = computed(() => !!(props.clearIcon && props.modelValue.length > 0));
-        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200) as ReturnType<typeof useDebounceFn> & { cancel: () => void };
+        const debouncedEmit = useDebounceFn((value: string) => emit("update:modelValue", value), 200) as ReturnType<
+            typeof useDebounceFn
+        > & { cancel: () => void };
 
         function clear() {
             debouncedEmit.cancel();

--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -83,6 +83,7 @@ const maps = useDexieLiveQueryWithDeps([searchVal, sortMethod, limit, filters], 
     const { terrain, gameType } = filters;
     const terrainFilters = new Set([...(<Terrain[]>Object.keys(terrain)).filter((key) => !!terrain[key]).map((k) => k)]);
     const gameTypeFilters = new Set([...(<GameType[]>Object.keys(gameType)).filter((key) => gameType[key]).map((k) => k)]);
+
     return db.maps
         .filter((map) => {
             const favorites = !filters.favoritesOnly || map.isFavorite;

--- a/src/renderer/components/maps/filters/MaxPlayersFilter.vue
+++ b/src/renderer/components/maps/filters/MaxPlayersFilter.vue
@@ -9,16 +9,25 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import Range from "@renderer/components/controls/Range.vue";
 import { mapsStore } from "@renderer/store/maps.store";
+import { watchThrottled } from "@vueuse/core";
 
 const { filters } = mapsStore;
 const range = ref([filters.minPlayers, filters.maxPlayers]);
-watch(range, (newRange) => {
-    filters.minPlayers = newRange[0];
-    filters.maxPlayers = newRange[1];
-});
+
+watchThrottled(
+    range,
+    (newRange) => {
+        filters.minPlayers = newRange[0];
+        filters.maxPlayers = newRange[1];
+    },
+    {
+        throttle: 200,
+        trailing: true,
+    },
+);
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/renderer/components/maps/filters/MaxPlayersFilter.vue
+++ b/src/renderer/components/maps/filters/MaxPlayersFilter.vue
@@ -26,7 +26,7 @@ watchThrottled(
     {
         throttle: 200,
         trailing: true,
-    },
+    }
 );
 </script>
 


### PR DESCRIPTION
## Description

Adds debounce and throttle to the map list to reduce re-renders of the UI to improve performance.

This affects specifically the SearchBox, I wouldn't do this for certain text fields like login fields, but for Search debouncing should be fine.

Video walk-through: https://customer-hrn0pvgcql3sn5ug.cloudflarestream.com/66b8c7ce931ccc8f7a4b9fad5da8669a/watch (too big for GitHub)

## Throttle vs Debounce

I use throttle for the `<Range>` to show updates as the user is dragging the slider. I use debounce for the SearchBox because map list re-renders / DB re-queries will lag the user typing. Debounce means the list only updates on a 200ms pause in typing, but typing is not lagged at all.

## Technicalities

Note that something that threw me off as someone who spends more time in React than Vue is that useThrottleFn has a `trailing` default of `false` while, watchThrottled as a `trailing` default of `true`. Trailing means the latest update is always fired. The different defaults threw me off initially, so for clarity I included `trailing: true` in the `watchThrottled` options, even though that is the default value.

`@vueuse` is used for the debouncing and throttling, this library is already used elsewhere in the project.

### AI / LLM usage statement:

VS Code auto-complete: **GitHub Copilot**
LLM code generation: **Minimal/none**
LLM consultation: **Consulted Claude**
