### PR TITLE
fix: Debug logs are not shown.

### DIFF
--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -105,6 +105,7 @@ console.log(`STATE_PATH: ${STATE_PATH}`);
 
 export const CONFIG_PATH = path.join(STATE_PATH, "config");
 export const LOGS_PATH = path.join(STATE_PATH, "logs");
+export const LOG_LEVEL = process.env.BAR_LOG_LEVEL || "info";
 
 // We will point engine at ASSETS_PATH as a base data directory to only read
 // data from, and at WRITE_DATA_PATH as data directory it can write to.

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -109,14 +109,11 @@ export const CONFIG_PATH = path.join(STATE_PATH, "config");
 
 // Logging configuration
 export const LOGS_PATH = path.join(STATE_PATH, "logs");
-const LogLevelSchema = Type.Union([Type.String({ pattern: "^(fatal|error|warn|info|debug|trace|silent)$" }), Type.Integer({ minimum: 10, maximum: 60, multipleOf: 10 })]);
-const isNumberLogLevel = process.env.BAR_LOG_LEVEL !== undefined && process.env.BAR_LOG_LEVEL.trim() !== "" && !Number.isNaN(Number(process.env.BAR_LOG_LEVEL));
-const formattedLogLevel: Static<typeof LogLevelSchema> = isNumberLogLevel ? Number(process.env.BAR_LOG_LEVEL) : (process.env.BAR_LOG_LEVEL ?? "info").toLowerCase();
+const LogLevelSchema = Type.String({ pattern: "^(fatal|error|warn|info|debug|trace|silent)$" });
+const formattedLogLevel: Static<typeof LogLevelSchema> = (process.env.BAR_LOG_LEVEL ?? "info").toLowerCase();
 const isValidLogLevel = Value.Check(LogLevelSchema, formattedLogLevel);
 if (!isValidLogLevel) {
-    console.warn(
-        `Invalid BAR_LOG_LEVEL: ${process.env.BAR_LOG_LEVEL}. Using default log level: info. Valid values are: fatal, error, warn, info, debug, trace, silent, or one of the pino level numbers (10, 20, 30, 40, 50, 60).`
-    );
+    console.warn(`Invalid BAR_LOG_LEVEL: ${process.env.BAR_LOG_LEVEL}. Using default log level: info. Valid values are: fatal, error, warn, info, debug, trace, silent.`);
 }
 export const LOG_LEVEL = isValidLogLevel ? formattedLogLevel : "info";
 

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -7,6 +7,8 @@ import fs from "fs";
 import { env } from "process";
 import { app } from "electron";
 import { homedir } from "os";
+import { Type, Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 
 // Should be the same as `productName` in electron-builder.ts
 // and in workaround in installer.nsh.
@@ -104,8 +106,19 @@ console.log(`ASSETS_PATH: ${ASSETS_PATH}`);
 console.log(`STATE_PATH: ${STATE_PATH}`);
 
 export const CONFIG_PATH = path.join(STATE_PATH, "config");
+
+// Logging configuration
 export const LOGS_PATH = path.join(STATE_PATH, "logs");
-export const LOG_LEVEL = process.env.BAR_LOG_LEVEL || "info";
+const LogLevelSchema = Type.Union([Type.String({ pattern: "^(fatal|error|warn|info|debug|trace|silent)$" }), Type.Integer({ minimum: 10, maximum: 60, multipleOf: 10 })]);
+const isNumberLogLevel = process.env.BAR_LOG_LEVEL !== undefined && process.env.BAR_LOG_LEVEL.trim() !== "" && !Number.isNaN(Number(process.env.BAR_LOG_LEVEL));
+const formattedLogLevel: Static<typeof LogLevelSchema> = isNumberLogLevel ? Number(process.env.BAR_LOG_LEVEL) : (process.env.BAR_LOG_LEVEL ?? "info").toLowerCase();
+const isValidLogLevel = Value.Check(LogLevelSchema, formattedLogLevel);
+if (!isValidLogLevel) {
+    console.warn(
+        `Invalid BAR_LOG_LEVEL: ${process.env.BAR_LOG_LEVEL}. Using default log level: info. Valid values are: fatal, error, warn, info, debug, trace, silent, or one of the pino level numbers (10, 20, 30, 40, 50, 60).`
+    );
+}
+export const LOG_LEVEL = isValidLogLevel ? formattedLogLevel : "info";
 
 // We will point engine at ASSETS_PATH as a base data directory to only read
 // data from, and at WRITE_DATA_PATH as data directory it can write to.

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -4,7 +4,7 @@
 
 import pino from "pino";
 import PinoPretty from "pino-pretty";
-import { LOGS_PATH } from "@main/config/app";
+import { LOGS_PATH, LOG_LEVEL } from "@main/config/app";
 import path from "path";
 import { mkdirSync } from "fs";
 
@@ -38,7 +38,15 @@ const logStream = PinoPretty({
     }),
 });
 
-const parentLogger = pino({}, pino.multistream([stdStream, logStream]));
+const parentLogger = pino(
+    {
+        level: LOG_LEVEL,
+    },
+    pino.multistream([
+        { stream: stdStream, level: LOG_LEVEL },
+        { stream: logStream, level: LOG_LEVEL },
+    ])
+);
 
 interface LoggerOptions {
     separator: string;


### PR DESCRIPTION
## Description

Unless I'm missing something, debug logs are never logged despite being used throughout the project.

For example:

https://github.com/beyond-all-reason/bar-lobby/blob/9373667ad95bb46e861ba4114a658a45f86412f6/src/main/main-window.ts#L79

is never logged.

## Cause

It seems related to the project using `pino.multistream`. Multistream sends logs to multiple locations. Pino's default level of `info` overrides any and all `debug` or `trace` logs _when using multistream._

https://github.com/beyond-all-reason/bar-lobby/blob/9373667ad95bb46e861ba4114a658a45f86412f6/src/main/utils/logger.ts#L41

The Pino docs state:

> In order for multistream to work, the log level must be set to the lowest level used in the streams array. Default is info.

_From [pinojs/pino API docs](https://github.com/pinojs/pino/blob/main/docs/api.md#pinomultistreamstreamsarray-opts--multistreamres)_

## The fix

This PR adds an ENV variable to set what that global level should be. The default is `info` which means by default logging works the same. But, developers can add `BAR_LOG_LEVEL=debug` or `BAR_LOG_LEVEL=trace` to show lower level logs.

## DX

We could even add scripts to make that easier, like:

```bash
npm run start:debug
```

```bash
npm run start:trace
```

But, I don't want to bloat the dev scripts unless contributors really want it.

### AI / LLM usage statement:

VS Code auto-complete: GitHub Copilot
LLM code generation: None
LLM consultation: Used Claude to investigate why Pino was tossing debug logs.

