### PR TITLE
Truncate long links in devlog to prevent scroll

### DIFF
--- a/src/renderer/components/misc/DevlogEntry.vue
+++ b/src/renderer/components/misc/DevlogEntry.vue
@@ -40,9 +40,11 @@ const description = computed(() => entry?.description?.split("|")[1]?.trim());
 }
 
 .dev-desc {
+    color: rgba(255, 255, 255, 0.8);
+    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
     font-size: 1em;
     margin-bottom: 15px;
-    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
-    color: rgba(255, 255, 255, 0.8);
+    overflow-x: hidden;
+    text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
## Problem

Long links in the devlog cause the panel to scroll horizontally despite already wrapping.

|Before|After|
|--|--|
|<img width="960" height="887" alt="The lobby devlog has a horizontal scrollbar because a single link is super long." src="https://github.com/user-attachments/assets/d8073fa1-92de-4146-8e90-e03aee09ee18" />|<img width="960" height="887" alt="The lobby devlog no longer with a horizontal scrollbar. The long link has an ellipses truncating it at the right edge." src="https://github.com/user-attachments/assets/fb3f127a-fe14-446c-abf8-3f168938989c" />|

## Fix

Adds `overflow: hidden` and `text-overflow: ellipsis` to fix this.

Fixes #608 

## Misc

I'm not sure if there's a CSS property order that's used. I just put it in alphabetical. But, I know prettier can auto format CSS property order, so maybe something to look into.

This devlog could also use a blurred background to improve readability like on the other pages.

## AI / LLM usage statement:

VS Code auto-complete: **GitHub Copilot**
LLMs: **Not used**

