### PR TITLE
fix: White screen flash on launch

### DIFF
--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -29,7 +29,6 @@ export function createWindow() {
 
     const mainWindow = new BrowserWindow({
         title: "Beyond All Reason",
-        fullscreen: settings.fullscreen,
         icon: nativeImage.createFromDataURL(icon),
         resizable: true,
         center: true,
@@ -82,6 +81,10 @@ export function createWindow() {
         mainWindow.setMenuBarVisibility(false);
         updateZoom();
         mainWindow.center();
+        // Note: `fullscreen: true` conflicts with `show: false`, so we apply fullscreen here.
+        if (settings.fullscreen) {
+            mainWindow.setFullScreen(true);
+        }
         mainWindow.show();
         mainWindow.focus();
     });

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -79,12 +79,12 @@ export function createWindow() {
             webContents.openDevTools();
         }
         mainWindow.setMenuBarVisibility(false);
-        updateZoom();
         mainWindow.center();
         // Note: `fullscreen: true` conflicts with `show: false`, so we apply fullscreen here.
         if (settings.fullscreen) {
             mainWindow.setFullScreen(true);
         }
+        updateZoom();
         mainWindow.show();
         mainWindow.focus();
     });

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -38,6 +38,7 @@ export function createWindow() {
         ...getWindowSize(settings.size),
         minWidth: 640,
         minHeight: 360,
+        backgroundColor: "#000000",
         webPreferences: {
             preload: path.join(__dirname, "../build/preload.js"),
             zoomFactor: 1,


### PR DESCRIPTION
## Description

On open, the client flash bangs the user if fullscreen is enabled. Fullscreen is on by default, so this affects all first-time users.

The client already uses:

https://github.com/beyond-all-reason/bar-lobby/blob/9373667ad95bb46e861ba4114a658a45f86412f6/src/main/main-window.ts#L37

which _should_ skip the white screen until the content starts rendering.

However, we also have `fullscreen: true` which negates `show: false`. The fullscreen setting causes the client to instantly show regardless.

## Fix

Moved the fullscreen setting into the `ready-to-show` handler, where `mainWindow.show()` is called.

## Comparison

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/7dec62bd-7060-4d52-81f5-143150146610"/>|<video src="https://github.com/user-attachments/assets/5375b178-4814-41c1-9102-94ff17027ed6" />|

You also spend less time looking at a black screen because the client is only shown once it's ready to render content.

## AI / LLM usage statement:

VS Code auto-complete: GitHub Copilot
LLM generation: None.
LLM consulation: Consulted Claude to help with triage.
