### PR TITLE
fix: Map downloads start at 100%

### DIFF
--- a/src/renderer/components/common/Progress.vue
+++ b/src/renderer/components/common/Progress.vue
@@ -68,7 +68,7 @@ watch(
     &.themed .progress__current {
         background: linear-gradient(rgba(217, 255, 0, 0.5) 0%, rgba(217, 255, 0, 0.5) 50%, rgba(194, 228, 0, 0.5) 51%);
         border-top: 1px solid rgba(255, 255, 255, 0.3);
-        transition: width 1s ease;
+        transition: width 300ms ease-out;
     }
     &.pulse .progress__current {
         animation: pulse 1s infinite;

--- a/src/renderer/components/common/Progress.vue
+++ b/src/renderer/components/common/Progress.vue
@@ -68,7 +68,7 @@ watch(
     &.themed .progress__current {
         background: linear-gradient(rgba(217, 255, 0, 0.5) 0%, rgba(217, 255, 0, 0.5) 50%, rgba(194, 228, 0, 0.5) 51%);
         border-top: 1px solid rgba(255, 255, 255, 0.3);
-        transition: width 300ms ease-out;
+        transition: width 300ms cubic-bezier(0.23, 0.29, 0.04, 1);
     }
     &.pulse .progress__current {
         animation: pulse 1s infinite;

--- a/src/renderer/components/navbar/Downloads.vue
+++ b/src/renderer/components/navbar/Downloads.vue
@@ -19,7 +19,13 @@ SPDX-License-Identifier: MIT
                             <span>{{ t("lobby.navbar.downloads.extracting") }}</span>
                         </div>
                         <template v-else>
-                            <Progress :percent="downloadPercent(download)" :text="barText(download)" :height="20" themed pulsating />
+                            <Progress
+                                :percent="download.totalBytes < 5000 ? 0 : downloadPercent(download)"
+                                :text="barText(download)"
+                                :height="20"
+                                themed
+                                pulsating
+                            />
                             <div class="downloads__detail">{{ detailText(download) }}</div>
                         </template>
                     </div>

--- a/src/renderer/components/navbar/Downloads.vue
+++ b/src/renderer/components/navbar/Downloads.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: MIT
                         </div>
                         <template v-else>
                             <Progress
-                                :percent="download.totalBytes < 5000 ? 0 : downloadPercent(download)"
+                                :percent="download.totalBytes < MIN_DOWNLOAD_BYTES ? 0 : downloadPercent(download)"
                                 :text="barText(download)"
                                 :height="20"
                                 themed
@@ -50,6 +50,8 @@ import Progress from "@renderer/components/common/Progress.vue";
 import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { useDownloadProgress } from "@renderer/composables/useDownloadProgress";
+
+const MIN_DOWNLOAD_BYTES = 5000; // 5 KB
 
 const { t } = useTypedI18n();
 const { allDownloads, downloadPercent, progressText } = useDownloadProgress();

--- a/src/renderer/components/navbar/Downloads.vue
+++ b/src/renderer/components/navbar/Downloads.vue
@@ -51,7 +51,7 @@ import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { useDownloadProgress } from "@renderer/composables/useDownloadProgress";
 
-const MIN_DOWNLOAD_BYTES = 5000; // 5 KB
+const MIN_DOWNLOAD_BYTES = 5 * 1024; // 5 KB
 
 const { t } = useTypedI18n();
 const { allDownloads, downloadPercent, progressText } = useDownloadProgress();

--- a/src/renderer/components/navbar/Downloads.vue
+++ b/src/renderer/components/navbar/Downloads.vue
@@ -49,9 +49,7 @@ import Loader from "@renderer/components/common/Loader.vue";
 import Progress from "@renderer/components/common/Progress.vue";
 import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
 import { useTypedI18n } from "@renderer/i18n";
-import { useDownloadProgress } from "@renderer/composables/useDownloadProgress";
-
-const MIN_DOWNLOAD_BYTES = 5 * 1024; // 5 KB
+import { MIN_DOWNLOAD_BYTES, useDownloadProgress } from "@renderer/composables/useDownloadProgress";
 
 const { t } = useTypedI18n();
 const { allDownloads, downloadPercent, progressText } = useDownloadProgress();

--- a/src/renderer/components/navbar/DownloadsButton.vue
+++ b/src/renderer/components/navbar/DownloadsButton.vue
@@ -5,7 +5,11 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <Button class="icon download-button" :style="`--downloadPercent: ${totalDownloadPercent * 100}%`" :class="{ pulse: isDownloading }">
+    <Button
+        class="icon download-button"
+        :style="`--downloadPercent: ${totalDownloadBytes.current < MIN_DOWNLOAD_BYTES ? 0 : (totalDownloadBytes.current / totalDownloadBytes.total) * 100}%`"
+        :class="{ pulse: isDownloading }"
+    >
         <Icon :icon="download" :height="40" />
     </Button>
 </template>
@@ -16,10 +20,9 @@ import download from "@iconify-icons/mdi/download";
 import { computed } from "vue";
 
 import Button from "@renderer/components/controls/Button.vue";
-import { useDownloadProgress } from "@renderer/composables/useDownloadProgress";
+import { MIN_DOWNLOAD_BYTES, useDownloadProgress } from "@renderer/composables/useDownloadProgress";
 
-const { allDownloads, totalDownloadPercent } = useDownloadProgress();
-
+const { allDownloads, totalDownloadBytes } = useDownloadProgress();
 const isDownloading = computed(() => allDownloads.value.length > 0);
 </script>
 
@@ -39,7 +42,7 @@ const isDownloading = computed(() => allDownloads.value.length > 0);
         background-position: 0 100%;
         background-size: 100% var(--downloadPercent);
         transform: scale(105%);
-        transition: background-size 1s ease;
+        transition: background-size 300ms cubic-bezier(0.23, 0.29, 0.04, 1);
     }
     &:hover:before {
         background:

--- a/src/renderer/composables/useDownloadProgress.ts
+++ b/src/renderer/composables/useDownloadProgress.ts
@@ -11,6 +11,7 @@ import { useTypedI18n } from "@renderer/i18n";
 const EMA_ALPHA = 0.3;
 const STALL_DECAY = 0.9;
 const MIN_UPDATE_INTERVAL = 0.25;
+export const MIN_DOWNLOAD_BYTES = 5 * 1024; // 5 KB
 
 interface SpeedEntry {
     prevBytes: number;
@@ -34,6 +35,16 @@ export function useDownloadProgress() {
             totalBytes += d.totalBytes;
         }
         return currentBytes / totalBytes || 0;
+    });
+
+    const totalDownloadBytes = computed(() => {
+        let currentBytes = 0;
+        let totalBytes = 0;
+        for (const d of allDownloads.value) {
+            currentBytes += d.currentBytes;
+            totalBytes += d.totalBytes;
+        }
+        return { current: currentBytes, total: totalBytes };
     });
 
     function downloadPercent(download: DownloadInfo): number {
@@ -102,6 +113,7 @@ export function useDownloadProgress() {
     return {
         allDownloads,
         totalDownloadPercent,
+        totalDownloadBytes,
         downloadPercent,
         progressText,
     };


### PR DESCRIPTION
## Description

When downloading maps, they visually show as starting at 100% and then animate the progress.

## Problem

This is due to two things:

1. The metadata gets its own progress bar and metadata is very small. (Often < 1 KB)
2. The progress bar has a CSS `transition` on progress change.

So, despite the metadata download happening instantly right before the full map download, the CSS transition causes the progress to lag behind and gives the impression that the map download starts at 100%.

## Solution

The simplest solution would be to just remove CSS transition on the progress state.

But, cool animations are core to the client design. Instead of doing that, this PR tells the `<Downloads>` component to use 0% progress on very small downloads.

It's currently set to 5 KB, which on most connections you would never see that download progress.

## Comparison

|Before|After|
|--|--|
|<video src="https://github.com/user-attachments/assets/1fd0de5b-2ad7-4e86-8d3d-f669b445a1a8" />|<video src="https://github.com/user-attachments/assets/1f50bc80-cbb7-41b2-9253-c99523066dd0" />|

### AI / LLM usage statement:

VS Code auto-complete: GitHub Copilot
LLM generation: None
LLM consultation: None

fixes #603
