### PR TITLE
Added multi-client launch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",
         "typecheck": "concurrently \"npm run typecheck:node\" \"npm run typecheck:web\"",
         "checks": "concurrently \"npm run typecheck:web\" \"npm run typecheck:node\" \"npm run lint\" \"npm run format:check\"",
-        "generate-i18n-assets": "node --import=tsx tools/generate-i18n-asset-files.ts"
+        "generate-i18n-assets": "node --import=tsx tools/generate-i18n-asset-files.ts",
+        "start:multi": "node --import=tsx tools/launch-clients.ts"
     },
     "engines": {
         "node": "22.18.0"

--- a/tools/launch-clients.ts
+++ b/tools/launch-clients.ts
@@ -5,7 +5,7 @@
 // This script is used to launch multiple instances of the BAR Lobby client with separate terminal windows for logging.
 // It uses electron-forge to compile and bundle it once, then spawns the requested number of clients into individual terminals with unique environment variables for state and assets paths.
 
-import { spawn } from "child_process";
+import { spawn, execSync } from "child_process";
 import os from "os";
 
 // 1. Read instance count from terminal flags (defaults to 2 if none provided)
@@ -52,11 +52,58 @@ build.on("close", (code: number | null) => {
                 shell: true,
             });
         } else {
-            // Linux fallback: Spawns an xterm or gnome-terminal window running the app
-            spawn("xterm", ["-title", `Client #${i} Log Stream`, "-e", "npx", "electron", "."], {
-                env: customEnv,
-                detached: true,
-            });
+            // Linux Mint Cinnamon native terminal check using an ESM-safe execution check
+            let hasGnomeTerminal = false;
+            try {
+                // Using execSync since it is always available via the child_process ecosystem
+                // const { execSync } = await import("child_process");
+                execSync("which gnome-terminal", { stdio: "ignore" });
+                hasGnomeTerminal = true;
+            } catch (e) {
+                hasGnomeTerminal = false;
+            }
+
+            // Command to execute your electron client.
+            // The bash 'exec' replaces the shell process with electron to save resources.
+            const runCmd = "npx electron .";
+
+            if (hasGnomeTerminal) {
+                // gnome-terminal uses -- to separate terminal flags from the executed command
+                spawn(
+                    "gnome-terminal",
+                    [
+                        "--title",
+                        `Client #${i} Log Stream`,
+                        "--",
+                        "bash",
+                        "-c",
+                        `${runCmd}; exec bash`, // '; exec bash' keeps the window open on crash/exit
+                    ],
+                    {
+                        env: customEnv,
+                        detached: true,
+                        stdio: "ignore",
+                    }
+                );
+            } else {
+                // Universal X11 fallback (requires xterm: sudo apt install xterm)
+                spawn(
+                    "xterm",
+                    [
+                        "-title",
+                        `Client #${i} Log Stream`,
+                        "-e",
+                        "bash",
+                        "-c",
+                        `${runCmd}; read -p "Press enter to close..."`, // Alternative keep-open method
+                    ],
+                    {
+                        env: customEnv,
+                        detached: true,
+                        stdio: "ignore",
+                    }
+                );
+            }
         }
     }
 

--- a/tools/launch-clients.ts
+++ b/tools/launch-clients.ts
@@ -4,6 +4,7 @@
 
 // This script is used to launch multiple instances of the BAR Lobby client with separate terminal windows for logging.
 // It uses electron-forge to compile and bundle it once, then spawns the requested number of clients into individual terminals with unique environment variables for state and assets paths.
+// This has been tested on Win11 and Linux Mint Cinnamon.
 
 import { spawn, execSync } from "child_process";
 import os from "os";
@@ -42,8 +43,6 @@ build.on("close", (code: number | null) => {
 
         console.log(`Spawning Client Shell #${i} -> STATE: ${statePath} | ASSETS: ${assetsPath}`);
         if (isWin) {
-            // Wrapping the title string in \" ensures Windows reads the client number dynamically
-            // /k keeps the terminal open to preserve log outputs if the application closes
             const windowTitle = `"Client #${i} Log Stream"`;
 
             spawn("cmd.exe", ["/c", "start", windowTitle, "cmd", "/c", "npx", "electron", "."], {
@@ -55,16 +54,12 @@ build.on("close", (code: number | null) => {
             // Linux Mint Cinnamon native terminal check using an ESM-safe execution check
             let hasGnomeTerminal = false;
             try {
-                // Using execSync since it is always available via the child_process ecosystem
-                // const { execSync } = await import("child_process");
                 execSync("which gnome-terminal", { stdio: "ignore" });
                 hasGnomeTerminal = true;
-            } catch (e) {
+            } catch {
                 hasGnomeTerminal = false;
             }
 
-            // Command to execute your electron client.
-            // The bash 'exec' replaces the shell process with electron to save resources.
             const runCmd = "npx electron .";
 
             if (hasGnomeTerminal) {

--- a/tools/launch-clients.ts
+++ b/tools/launch-clients.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+// This script is used to launch multiple instances of the BAR Lobby client with separate terminal windows for logging.
+// It uses electron-forge to compile and bundle it once, then spawns the requested number of clients into individual terminals with unique environment variables for state and assets paths.
+
+import { spawn } from "child_process";
+import os from "os";
+
+// 1. Read instance count from terminal flags (defaults to 2 if none provided)
+const args: string[] = process.argv.slice(2);
+const passedCount: number = parseInt(args, 10);
+const CLIENT_COUNT: number = !isNaN(passedCount) && passedCount > 0 ? passedCount : 2;
+
+console.log(`Preparing to compile and launch ${CLIENT_COUNT} instances...`);
+
+// 2. Compile assets and bundle once via electron-forge
+const isWin: boolean = os.platform() === "win32";
+const npxCmd: string = isWin ? "npx.cmd" : "npx";
+const build = spawn(npxCmd, ["electron-forge", "package"], { shell: true, stdio: "inherit" });
+
+build.on("close", (code: number | null) => {
+    if (code !== 0) {
+        console.error("Build failed. Aborting launch.");
+        process.exit(code ?? 1);
+    }
+
+    // 3. Loop and spawn the requested number of clients into individual terminals
+    for (let i = 1; i <= CLIENT_COUNT; i++) {
+        const suffix: string = i === 1 ? "" : `-${i}`;
+        const statePath: string = `state${suffix}`;
+        const assetsPath: string = `assets${suffix}`;
+
+        const customEnv: NodeJS.ProcessEnv = {
+            ...process.env,
+            NODE_ENV: "production",
+            NODE_OPTIONS: "--enable-source-maps",
+            BAR_STATE_PATH: statePath,
+            BAR_ASSETS_PATH: assetsPath,
+        };
+
+        console.log(`Spawning Client Shell #${i} -> STATE: ${statePath} | ASSETS: ${assetsPath}`);
+        if (isWin) {
+            // Wrapping the title string in \" ensures Windows reads the client number dynamically
+            // /k keeps the terminal open to preserve log outputs if the application closes
+            const windowTitle = `"Client #${i} Log Stream"`;
+
+            spawn("cmd.exe", ["/c", "start", windowTitle, "cmd", "/c", "npx", "electron", "."], {
+                env: customEnv,
+                detached: true,
+                shell: true,
+            });
+        } else {
+            // Linux fallback: Spawns an xterm or gnome-terminal window running the app
+            spawn("xterm", ["-title", `Client #${i} Log Stream`, "-e", "npx", "electron", "."], {
+                env: customEnv,
+                detached: true,
+            });
+        }
+    }
+
+    console.log(`Successfully opened ${CLIENT_COUNT} separate terminal windows tracking live logs.`);
+    process.exit(0);
+});


### PR DESCRIPTION
Script added that builds one version of the client and then launches N number of clients simultaneously from that one build.

To use, run `npm run start:multi -- 2` (or more). If no number is provided, default behavior is 2 clients.

Terminal windows will spawn for logging output from each client.

### AI / LLM usage statement:
Google Gemini was used to generate the initial script, add specific desired behaviors, and troubleshoot platform-specific results. Code was evaluated and tested by myself on Windows 11 and Linux Mint Cinnamon (via VirtualBox).