### PR TITLE
Matchmaking fixes

### DIFF
--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -133,7 +133,7 @@
                     "searchGame": "Search game",
                     "joinRequested": "Joining queue",
                     "searchingForOpponent": "Searching for opponent",
-                    "matchFound": "Match found",
+                    "matchFound": "Matched - Click to Ready",
                     "accepted": "Accepted",
                     "cancel": "Cancel"
                 },

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -1964,7 +1964,7 @@
                     "searchGame": "Search game",
                     "joinRequested": "Joining queue",
                     "searchingForOpponent": "Searching for opponent",
-                    "matchFound": "Match found",
+                    "matchFound": "Matched - Click to Ready",
                     "accepted": "Accepted",
                     "cancel": "Cancel"
                 },

--- a/src/renderer/store/game.store.ts
+++ b/src/renderer/store/game.store.ts
@@ -8,6 +8,7 @@ import { Replay } from "@main/content/replays/replay";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
 import { notificationsApi } from "@renderer/api/notifications";
 import { reactive, watch } from "vue";
+import { matchmakingStore, MatchmakingStatus } from "./matchmaking.store";
 
 export enum GameStatus {
     LOADING,
@@ -111,6 +112,9 @@ export async function initGameStore() {
     window.game.onGameClosed(() => {
         console.debug("Game closed");
         gameStore.status = GameStatus.CLOSED;
+        if (matchmakingStore.status !== MatchmakingStatus.Idle) {
+            matchmakingStore.status = MatchmakingStatus.Idle;
+        }
     });
     gameStore.isInitialized = true;
 }


### PR DESCRIPTION
Matchmaking button verbiage changed to indicate the button should be clicked to accept a match once one was found. Additionally fixed an error where the matchmaking state was not being reset after a battle was closed, leaving the client in "Accepted" state instead of "Idle".

### AI / LLM usage statement:
No AI was used for this PR.