### PR TITLE
Update matchmaking.vue

### DIFF
--- a/src/renderer/views/play/matchmaking.vue
+++ b/src/renderer/views/play/matchmaking.vue
@@ -129,6 +129,7 @@ const downloadsRequired = computed(() => {
 
 const downloadsAreRequiredForSelected = computed(() => {
     // 0 returns falsy, anything else returns truthy, so this works to determine if there are any downloads required.
+    if (!matchmakingStore.selectedQueue) return false;
     return (
         matchmakingStore.downloadsRequired[matchmakingStore.selectedQueue].maps.length +
         matchmakingStore.downloadsRequired[matchmakingStore.selectedQueue].engines.length +


### PR DESCRIPTION
Prevents issues where there is not a selected queue yet, and as a result the required downloads cannot be ascertained.

Note that the first queue in the list received will be auto-selected by matchmaking.store as the selected queue, so this required no other changes.

Fixes #621 

### AI / LLM usage statement:
No AI was used for this PR.