### PR TITLE
Fix map spring name having trailing "undefined"/space when mapinfo.lua version is missing

### DIFF
--- a/tests/unit/main/ultrasimple-map-parser.spec.ts
+++ b/tests/unit/main/ultrasimple-map-parser.spec.ts
@@ -50,9 +50,9 @@ describe("UltraSimpleMapParser", () => {
         expect(result.springName).toBe("Some Map 1.2");
     });
 
-    // Regression test: a missing "version" field used to fall through to the 
-    // "append version" branch, producing "<name> undefined"/"<name> " which 
-    // never matched the expected spring name, so the map was re-downloaded 
+    // Regression test: a missing "version" field used to fall through to the
+    // "append version" branch, producing "<name> undefined"/"<name> " which
+    // never matched the expected spring name, so the map was re-downloaded
     // on every launch instead of being recognized as already installed.
     it("does not append a trailing space/undefined when version is missing (issue #629)", async () => {
         mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Paradise Lost V4" }));

--- a/tests/unit/main/ultrasimple-map-parser.spec.ts
+++ b/tests/unit/main/ultrasimple-map-parser.spec.ts
@@ -54,7 +54,7 @@ describe("UltraSimpleMapParser", () => {
     // "append version" branch, producing "<name> undefined"/"<name> " which
     // never matched the expected spring name, so the map was re-downloaded
     // on every launch instead of being recognized as already installed.
-    it("does not append a trailing space/undefined when version is missing (issue #629)", async () => {
+    it("does not append a trailing space/undefined when version is missing", async () => {
         mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Paradise Lost V4" }));
 
         const result = await parser.parseMap("/maps/paradise_lost_v4.sd7");

--- a/tests/unit/main/ultrasimple-map-parser.spec.ts
+++ b/tests/unit/main/ultrasimple-map-parser.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockReadSpecificFile } = vi.hoisted(() => ({
+    mockReadSpecificFile: vi.fn(),
+}));
+
+vi.mock("@main/utils/extract-7z", () => ({
+    readSpecificFile: mockReadSpecificFile,
+}));
+
+import { UltraSimpleMapParser } from "$/map-parser/ultrasimple-map-parser";
+
+function mapinfoLua(fields: Record<string, string>): string {
+    const body = Object.entries(fields)
+        .map(([key, value]) => `    ${key} = "${value}",`)
+        .join("\n");
+    return `local mapinfo = {\n${body}\n}\nreturn mapinfo\n`;
+}
+
+describe("UltraSimpleMapParser", () => {
+    let parser: UltraSimpleMapParser;
+
+    beforeEach(() => {
+        parser = new UltraSimpleMapParser();
+        mockReadSpecificFile.mockReset();
+    });
+
+    it("rejects non-.sd7 files", async () => {
+        await expect(parser.parseMap("/maps/some_map.sdz")).rejects.toThrow(/extension is not supported/);
+        expect(mockReadSpecificFile).not.toHaveBeenCalled();
+    });
+
+    it("uses name as-is when version is already part of the name", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Comet Catcher Remake 1.9", version: "1.9" }));
+
+        const result = await parser.parseMap("/maps/comet_catcher_remake_1_9.sd7");
+
+        expect(result.springName).toBe("Comet Catcher Remake 1.9");
+    });
+
+    it("appends the version when it isn't already part of the name", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Some Map", version: "1.2" }));
+
+        const result = await parser.parseMap("/maps/some_map.sd7");
+
+        expect(result.springName).toBe("Some Map 1.2");
+    });
+
+    // Regression test: a missing "version" field used to fall through to the 
+    // "append version" branch, producing "<name> undefined"/"<name> " which 
+    // never matched the expected spring name, so the map was re-downloaded 
+    // on every launch instead of being recognized as already installed.
+    it("does not append a trailing space/undefined when version is missing (issue #629)", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Paradise Lost V4" }));
+
+        const result = await parser.parseMap("/maps/paradise_lost_v4.sd7");
+
+        expect(result.springName).toBe("Paradise Lost V4");
+        expect(result.springName.endsWith(" ")).toBe(false);
+    });
+
+    it("does not append a trailing space when version is an empty string", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ name: "Paradise Lost V4", version: "" }));
+
+        const result = await parser.parseMap("/maps/paradise_lost_v4.sd7");
+
+        expect(result.springName).toBe("Paradise Lost V4");
+        expect(result.springName.endsWith(" ")).toBe(false);
+    });
+
+    it("falls back to the smtFileName when no name is present", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ smtFileName: "some_map.smt" }));
+
+        const result = await parser.parseMap("/maps/some_map.sd7");
+
+        expect(result.springName).toBe("some_map.smt");
+    });
+
+    it("falls back to the file name when neither name nor smtFileName is present", async () => {
+        mockReadSpecificFile.mockResolvedValue(mapinfoLua({ description: "no name or smtFileName here" }));
+
+        const result = await parser.parseMap("/maps/mystery_map.sd7");
+
+        expect(result.springName).toBe("mystery_map");
+        expect(result.fileName).toBe("mystery_map");
+        expect(result.fileNameWithExt).toBe("mystery_map.sd7");
+    });
+});

--- a/vendor/map-parser/ultrasimple-map-parser.ts
+++ b/vendor/map-parser/ultrasimple-map-parser.ts
@@ -27,10 +27,13 @@ export class UltraSimpleMapParser {
             const rawMapinfo = await readSpecificFile(mapFilePath, "mapinfo.lua")
             const mapInfo = await this.parseMapInfo(rawMapinfo);
             let springName = "";
-            if (mapInfo && mapInfo.name && mapInfo.version && mapInfo.name.includes(mapInfo.version!)) {
-                springName = mapInfo.name;
-            } else if (mapInfo && mapInfo.name) {
+            if (mapInfo && mapInfo?.name && mapInfo.version && !mapInfo.name.includes(mapInfo.version)) {
                 springName = `${mapInfo.name} ${mapInfo.version}`;
+            } else if (mapInfo?.name) {
+                // missing/empty "version" field in mapinfo.lua. Don't append an
+                // empty/undefined version here, or springName ends up with a trailing space
+                // that never matches the expected spring name (map re-downloads every launch).
+                springName = mapInfo.name;
             } else if (mapInfo.smtFileName) {
                 springName = mapInfo.smtFileName;
             } else {


### PR DESCRIPTION
Closes #629

Maps whose `mapinfo.lua` is missing a `version` field (or has an empty one) were never recognized as "already downloaded" on subsequent launches, because their derived spring name was malformed.

## Problem

Any map with a `version` that is undefined or empty fell into the branch that appends the version to the name, producing `"Paradise Lost V4 undefined"` or `"Paradise Lost V4 "` (trailing space) instead of `"Paradise Lost V4"`. That string is used as the lookup key for "is this map installed", so it never matched the name reported by the matchmaker/queue, and the client re-triggered a download of the map on every launch even though the file was already present.

### Tests

Added `tests/unit/main/ultrasimple-map-parser.spec.ts` covering different cases, including a regression test for the error case.

### AI / LLM usage statement

AI for tests, Codex.
