### PR TITLE
feat: show active map queue count on Downloads

### DIFF
--- a/src/main/content/maps/map-content.ts
+++ b/src/main/content/maps/map-content.ts
@@ -15,7 +15,6 @@ import chokidar, { FSWatcher } from "chokidar";
 import { UltraSimpleMapParser } from "$/map-parser/ultrasimple-map-parser";
 import { removeFromArray } from "$/jaz-ts-utils/object";
 import { engineContentAPI } from "@main/content/engine/engine-content";
-import { settingsService } from "@main/services/settings.service";
 import { calcChecksum } from "@main/utils/checksums";
 
 const log = logger("map-content.ts");

--- a/src/main/content/maps/map-content.ts
+++ b/src/main/content/maps/map-content.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { MapData } from "@main/content/maps/map-data";
+import { MapDownloadQueue, type MapDownloadQueueEntry } from "@main/content/maps/map-download-queue";
 import { logger } from "@main/utils/logger";
 import { Signal } from "$/jaz-ts-utils/signal";
 import { PrDownloaderAPI } from "@main/content/pr-downloader";
@@ -14,9 +15,12 @@ import chokidar, { FSWatcher } from "chokidar";
 import { UltraSimpleMapParser } from "$/map-parser/ultrasimple-map-parser";
 import { removeFromArray } from "$/jaz-ts-utils/object";
 import { engineContentAPI } from "@main/content/engine/engine-content";
+import { settingsService } from "@main/services/settings.service";
 import { calcChecksum } from "@main/utils/checksums";
 
 const log = logger("map-content.ts");
+
+export type { MapDownloadQueueEntry } from "@main/content/maps/map-download-queue";
 
 /**
  * @todo replace queue method with syncMapCache function once prd returns map file name
@@ -32,6 +36,9 @@ export class MapContentAPI extends PrDownloaderAPI<string, MapData> {
 
     protected cachingMaps = false;
     protected readonly mapCacheQueue: Set<string> = new Set();
+    private readonly mapDownloadQueue = new MapDownloadQueue((springName) => this.downloadQueuedMap(springName));
+
+    public readonly onMapDownloadQueueChanged = this.mapDownloadQueue.onChanged;
 
     public override async init() {
         this.initLookupMaps();
@@ -140,21 +147,22 @@ export class MapContentAPI extends PrDownloaderAPI<string, MapData> {
         return this.mapNameFileNameLookup[springName] !== undefined;
     }
 
-    public async downloadMaps(springNames: string[]) {
-        return Promise.all(springNames.map((springName) => this.downloadMap(springName)));
+    public getMapDownloadQueue(): MapDownloadQueueEntry[] {
+        return this.mapDownloadQueue.getSnapshot();
     }
 
-    public async downloadMap(springName: string) {
+    public async downloadMaps(springNames: string[]) {
+        return await Promise.all(springNames.map((springName) => this.downloadMap(springName)));
+    }
+
+    public downloadMap(springName: string): Promise<void> {
+        if (this.isVersionInstalled(springName)) return Promise.resolve();
+
+        return this.mapDownloadQueue.enqueue(springName);
+    }
+
+    private async downloadQueuedMap(springName: string) {
         if (this.isVersionInstalled(springName)) return;
-        if (this.currentDownloads.some((download) => download.name === springName)) {
-            return await new Promise<void>((resolve) => {
-                this.onDownloadComplete.addOnce((mapData) => {
-                    if (mapData.name === springName) {
-                        resolve();
-                    }
-                });
-            });
-        }
         const downloadInfo = await this.downloadContent("map", springName);
         removeFromArray(this.currentDownloads, downloadInfo);
         this.onDownloadComplete.dispatch(downloadInfo);

--- a/src/main/content/maps/map-download-queue.ts
+++ b/src/main/content/maps/map-download-queue.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { Signal } from "$/jaz-ts-utils/signal";
+
+export type MapDownloadQueueEntry = {
+    springName: string;
+    status: "queued" | "downloading";
+};
+
+type QueuedMapDownload = {
+    springName: string;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+};
+
+/** Owns the serial map-download lifecycle and exposes only observable queue state. */
+export class MapDownloadQueue {
+    public readonly onChanged: Signal<MapDownloadQueueEntry[]> = new Signal();
+
+    private readonly queue: QueuedMapDownload[] = [];
+    private readonly pendingDownloads = new Map<string, Promise<void>>();
+    private activeDownload?: QueuedMapDownload;
+    private isProcessing = false;
+
+    public constructor(private readonly download: (springName: string) => Promise<void>) {}
+
+    public getSnapshot(): MapDownloadQueueEntry[] {
+        return [
+            ...(this.activeDownload ? [{ springName: this.activeDownload.springName, status: "downloading" as const }] : []),
+            ...this.queue.map((download) => ({ springName: download.springName, status: "queued" as const })),
+        ];
+    }
+
+    public enqueue(springName: string): Promise<void> {
+        const pendingDownload = this.pendingDownloads.get(springName);
+        if (pendingDownload) return pendingDownload;
+
+        let resolve!: () => void;
+        let reject!: (error: unknown) => void;
+        const download = new Promise<void>((resolveDownload, rejectDownload) => {
+            resolve = resolveDownload;
+            reject = rejectDownload;
+        });
+
+        this.pendingDownloads.set(springName, download);
+        this.queue.push({ springName, resolve, reject });
+        this.dispatchChanged();
+        void this.process();
+        return download;
+    }
+
+    private async process() {
+        if (this.isProcessing) return;
+
+        this.isProcessing = true;
+        try {
+            while (this.queue.length > 0) {
+                const queuedDownload = this.queue.shift();
+                if (!queuedDownload) continue;
+
+                this.activeDownload = queuedDownload;
+                this.dispatchChanged();
+                try {
+                    await this.download(queuedDownload.springName);
+                    queuedDownload.resolve();
+                } catch (error) {
+                    queuedDownload.reject(error);
+                } finally {
+                    this.pendingDownloads.delete(queuedDownload.springName);
+                    this.activeDownload = undefined;
+                    this.dispatchChanged();
+                }
+            }
+        } finally {
+            this.isProcessing = false;
+        }
+    }
+
+    private dispatchChanged() {
+        this.onChanged.dispatch(this.getSnapshot());
+    }
+}

--- a/src/main/services/maps.service.ts
+++ b/src/main/services/maps.service.ts
@@ -54,6 +54,7 @@ async function fetchAllMaps(): Promise<[MapData[], MapDownloadData[]]> {
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     ipcMain.handle("maps:downloadMap", (_, springName: string) => mapContentAPI.downloadMap(springName));
     ipcMain.handle("maps:downloadMaps", (_, springNames: string[]) => mapContentAPI.downloadMaps(springNames));
+    ipcMain.handle("maps:getDownloadQueue", () => mapContentAPI.getMapDownloadQueue());
     ipcMain.handle("maps:getInstalledMapNames", () => Object.keys(mapContentAPI.mapNameFileNameLookup));
     ipcMain.handle("maps:getInstalledVersions", () => mapContentAPI.availableVersions);
     ipcMain.handle("maps:isVersionInstalled", (_, id: string) => mapContentAPI.isVersionInstalled(id));
@@ -63,6 +64,9 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     ipcMain.handle("maps:online:fetchMapImages", (_, imageSource: string) => fetchMapImages(imageSource));
 
     // Events
+    mapContentAPI.onMapDownloadQueueChanged.add((queue) => {
+        webContents.send("maps:downloadQueueChanged", queue);
+    });
     mapContentAPI.onMapAdded.add((filename: string) => {
         webContents.send("maps:mapAdded", filename);
     });

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -10,6 +10,7 @@ import type { Info } from "@main/services/info.service";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, IpcRenderer, IpcRendererEvent, WebContents } from "electron";
 import type { logLevels } from "@main/services/log.service";
 import type { MapData, MapDownloadData } from "@main/content/maps/map-data";
+import type { MapDownloadQueueEntry } from "@main/content/maps/map-content";
 import type { MultiplayerLaunchSettings } from "@main/game/game";
 import type { NewsFeedData } from "@main/services/news.service";
 import type { Replay } from "@main/content/replays/replay";
@@ -36,6 +37,7 @@ export type IPCEvents = {
     "downloads:map:start": (downloadInfo: DownloadInfo) => void;
     "game:closed": () => void;
     "game:launched": () => void;
+    "maps:downloadQueueChanged": (queue: MapDownloadQueueEntry[]) => void;
     "maps:mapAdded": (filename: string) => void;
     "maps:mapDeleted": (filename: string) => void;
     "navigation:navigateTo": (target: string) => void;
@@ -88,6 +90,7 @@ export type IPCCommands = {
     "maps:attemptCacheErrorMaps": () => void;
     "maps:downloadMap": (springName: string) => void;
     "maps:downloadMaps": (springNames: string[]) => void[];
+    "maps:getDownloadQueue": () => MapDownloadQueueEntry[];
     "maps:getInstalledMapNames": () => string[];
     "maps:getInstalledVersions": () => Map<string, MapData>;
     "maps:isVersionInstalled": (springName: string) => boolean;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -9,6 +9,7 @@ import { Settings } from "@main/services/settings.service";
 import { EngineVersion } from "@main/content/engine/engine-version";
 import { GameVersion } from "@main/content/game/game-version";
 import { MapData, MapDownloadData } from "@main/content/maps/map-data";
+import type { MapDownloadQueueEntry } from "@main/content/maps/map-content";
 import { DownloadInfo } from "@main/content/downloads";
 import { Info } from "@main/services/info.service";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
@@ -121,6 +122,7 @@ const mapsApi = {
     // Content
     downloadMap: (springName: string): Promise<void> => ipcRenderer.invoke("maps:downloadMap", springName),
     downloadMaps: (springNames: string[]): Promise<void[]> => ipcRenderer.invoke("maps:downloadMaps", springNames),
+    getDownloadQueue: () => ipcRenderer.invoke("maps:getDownloadQueue"),
     getInstalledMapNames: (): Promise<string[]> => ipcRenderer.invoke("maps:getInstalledMapNames"),
     getInstalledVersions: (): Promise<Map<string, MapData>> => ipcRenderer.invoke("maps:getInstalledVersions"),
     isVersionInstalled: (springName: string): Promise<boolean> => ipcRenderer.invoke("maps:isVersionInstalled", springName),
@@ -130,6 +132,7 @@ const mapsApi = {
     fetchMapImages: (imageSource: string): Promise<ArrayBuffer | undefined> => ipcRenderer.invoke("maps:online:fetchMapImages", imageSource),
 
     // Events
+    onDownloadQueueChanged: (callback: (queue: MapDownloadQueueEntry[]) => void) => ipcRenderer.on("maps:downloadQueueChanged", (_event, queue) => callback(queue)),
     onMapAdded: (callback: (filename: string) => void) => ipcRenderer.on("maps:mapAdded", (_event, filename) => callback(filename)),
     onMapDeleted: (callback: (filename: string) => void) => ipcRenderer.on("maps:mapDeleted", (_event, filename) => callback(filename)),
 };

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2379,6 +2379,8 @@
                     "labelName": "Name",
                     "labelSize": "Size",
                     "downloadSelected": "Download selected ({count})",
+                    "selectAll": "Select all available",
+                    "clearSelection": "Clear selection",
                     "noMapsFound": "No maps found!",
                     "pleaseTryDifferent": "Please try different keywords / filters"
                 },

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2056,6 +2056,8 @@
             },
             "downloads": {
                 "noDownloads": "No downloads active",
+                "queued": "Queued",
+                "downloading": "Downloading",
                 "moreDownloads": "and {count} more...",
                 "starting": "Starting...",
                 "extracting": "Extracting...",
@@ -2376,6 +2378,7 @@
                     "sortBy": "Sort By",
                     "labelName": "Name",
                     "labelSize": "Size",
+                    "downloadSelected": "Download selected ({count})",
                     "noMapsFound": "No maps found!",
                     "pleaseTryDifferent": "Please try different keywords / filters"
                 },

--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -14,13 +14,24 @@ SPDX-License-Identifier: MIT
                 :label="t('lobby.components.maps.mapListComponents.sortBy')"
                 optionLabel="label"
             />
+            <Button class="green" :disabled="selectedDownloadMapNames.length === 0" @click="downloadSelectedMaps">
+                {{ t("lobby.components.maps.mapListComponents.downloadSelected", { count: selectedDownloadMapNames.length }) }}
+            </Button>
         </div>
 
         <div class="flex-col flex-grow fullheight">
             <div class="scroll-container" style="overflow-y: scroll" ref="el">
                 <div class="maps">
                     <TransitionGroup name="maps-list">
-                        <MapOverviewCard v-for="map in maps" :key="map.springName" :map="map" @click="mapSelected(map)" />
+                        <div v-for="map in maps" :key="map.springName" class="map-card">
+                            <MapOverviewCard :map="map" @click="mapSelected(map)" />
+                            <div v-if="isMapDownloadEligible(map)" class="map-card__selection" @click.stop>
+                                <Checkbox
+                                    :modelValue="selectedMapNames.has(map.springName)"
+                                    @update:modelValue="toggleMapSelection(map.springName)"
+                                />
+                            </div>
+                        </div>
                     </TransitionGroup>
                     <div v-if="(maps?.length || 0) <= 0">
                         <h4>{{ t("lobby.components.maps.mapListComponents.noMapsFound") }}</h4>
@@ -40,7 +51,10 @@ SPDX-License-Identifier: MIT
  * - Easy one click install button
  * - Demo map button that launches a simple offline game on the map
  */
-import { Ref, ref } from "vue";
+import { computed, Ref, ref } from "vue";
+
+import Button from "@renderer/components/controls/Button.vue";
+import Checkbox from "@renderer/components/controls/Checkbox.vue";
 
 import SearchBox from "@renderer/components/controls/SearchBox.vue";
 import Select from "@renderer/components/controls/Select.vue";
@@ -49,7 +63,8 @@ import { type MapData } from "@main/content/maps/map-data";
 import type { GameType, Terrain } from "@main/content/maps/map-metadata";
 import { db } from "@renderer/store/db";
 import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQuery";
-import { mapsStore } from "@renderer/store/maps.store";
+import { mapsStore, queueMapDownloads } from "@renderer/store/maps.store";
+import { downloadsStore } from "@renderer/store/downloads.store";
 
 import { useInfiniteScroll } from "@vueuse/core";
 import { useTypedI18n } from "@renderer/i18n";
@@ -102,6 +117,34 @@ const maps = useDexieLiveQueryWithDeps([searchVal, sortMethod, limit, filters], 
         .sortBy(sortMethod.value?.dbKey || "");
 });
 
+const selectedMapNames = ref(new Set<string>());
+const queuedMapNames = computed(() => new Set(downloadsStore.mapDownloadQueue.map((entry) => entry.springName)));
+const selectedDownloadMapNames = computed(() =>
+    (maps.value ?? [])
+        .filter((map) => selectedMapNames.value.has(map.springName) && isMapDownloadEligible(map))
+        .map((map) => map.springName)
+);
+
+function isMapDownloadEligible(map: MapData) {
+    return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);
+}
+
+function toggleMapSelection(springName: string) {
+    const nextSelection = new Set(selectedMapNames.value);
+    if (nextSelection.has(springName)) {
+        nextSelection.delete(springName);
+    } else {
+        nextSelection.add(springName);
+    }
+    selectedMapNames.value = nextSelection;
+}
+
+function downloadSelectedMaps() {
+    const springNames = selectedDownloadMapNames.value;
+    queueMapDownloads(springNames);
+    selectedMapNames.value = new Set();
+}
+
 function mapSelected(map: MapData) {
     emit("map-selected", map);
 }
@@ -113,6 +156,18 @@ function mapSelected(map: MapData) {
     grid-gap: 15px;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     padding-right: 10px;
+}
+
+.map-card {
+    position: relative;
+    cursor: pointer;
+
+    &__selection {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        z-index: 6;
+    }
 }
 
 // Transition

--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -117,8 +117,13 @@ const maps = useDexieLiveQueryWithDeps([searchVal, sortMethod, limit, filters], 
         .sortBy(sortMethod.value?.dbKey || "");
 });
 
-const { selectedMapNames, selectedDownloadMapNames, isEligible: isMapDownloadEligible, submit: downloadSelectedMaps, toggle: toggleMapSelection } =
-    useMapDownloadSelection(maps);
+const {
+    selectedMapNames,
+    selectedDownloadMapNames,
+    isEligible: isMapDownloadEligible,
+    submit: downloadSelectedMaps,
+    toggle: toggleMapSelection,
+} = useMapDownloadSelection(maps);
 
 function mapSelected(map: MapData) {
     emit("map-selected", map);

--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -14,7 +14,13 @@ SPDX-License-Identifier: MIT
                 :label="t('lobby.components.maps.mapListComponents.sortBy')"
                 optionLabel="label"
             />
-            <Button class="green" :disabled="selectedDownloadMapNames.length === 0" @click="downloadSelectedMaps">
+            <Button class="gray select-all-maps" @click="selectAllMapSelections">
+                {{ t("lobby.components.maps.mapListComponents.selectAll") }}
+            </Button>
+            <Button class="gray clear-all-maps" :disabled="selectedDownloadMapNames.length === 0" @click="clearMapSelections">
+                {{ t("lobby.components.maps.mapListComponents.clearSelection") }}
+            </Button>
+            <Button class="green download-selected" :disabled="selectedDownloadMapNames.length === 0" @click="downloadSelectedMaps">
                 {{ t("lobby.components.maps.mapListComponents.downloadSelected", { count: selectedDownloadMapNames.length }) }}
             </Button>
         </div>
@@ -123,6 +129,8 @@ const {
     isEligible: isMapDownloadEligible,
     submit: downloadSelectedMaps,
     toggle: toggleMapSelection,
+    selectAll: selectAllMapSelections,
+    clearSelection: clearMapSelections,
 } = useMapDownloadSelection(maps);
 
 function mapSelected(map: MapData) {

--- a/src/renderer/components/maps/MapListComponent.vue
+++ b/src/renderer/components/maps/MapListComponent.vue
@@ -51,7 +51,7 @@ SPDX-License-Identifier: MIT
  * - Easy one click install button
  * - Demo map button that launches a simple offline game on the map
  */
-import { computed, Ref, ref } from "vue";
+import { Ref, ref } from "vue";
 
 import Button from "@renderer/components/controls/Button.vue";
 import Checkbox from "@renderer/components/controls/Checkbox.vue";
@@ -63,8 +63,8 @@ import { type MapData } from "@main/content/maps/map-data";
 import type { GameType, Terrain } from "@main/content/maps/map-metadata";
 import { db } from "@renderer/store/db";
 import { useDexieLiveQueryWithDeps } from "@renderer/composables/useDexieLiveQuery";
-import { mapsStore, queueMapDownloads } from "@renderer/store/maps.store";
-import { downloadsStore } from "@renderer/store/downloads.store";
+import { useMapDownloadSelection } from "@renderer/composables/useMapDownloadSelection";
+import { mapsStore } from "@renderer/store/maps.store";
 
 import { useInfiniteScroll } from "@vueuse/core";
 import { useTypedI18n } from "@renderer/i18n";
@@ -117,33 +117,8 @@ const maps = useDexieLiveQueryWithDeps([searchVal, sortMethod, limit, filters], 
         .sortBy(sortMethod.value?.dbKey || "");
 });
 
-const selectedMapNames = ref(new Set<string>());
-const queuedMapNames = computed(() => new Set(downloadsStore.mapDownloadQueue.map((entry) => entry.springName)));
-const selectedDownloadMapNames = computed(() =>
-    (maps.value ?? [])
-        .filter((map) => selectedMapNames.value.has(map.springName) && isMapDownloadEligible(map))
-        .map((map) => map.springName)
-);
-
-function isMapDownloadEligible(map: MapData) {
-    return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);
-}
-
-function toggleMapSelection(springName: string) {
-    const nextSelection = new Set(selectedMapNames.value);
-    if (nextSelection.has(springName)) {
-        nextSelection.delete(springName);
-    } else {
-        nextSelection.add(springName);
-    }
-    selectedMapNames.value = nextSelection;
-}
-
-function downloadSelectedMaps() {
-    const springNames = selectedDownloadMapNames.value;
-    queueMapDownloads(springNames);
-    selectedMapNames.value = new Set();
-}
+const { selectedMapNames, selectedDownloadMapNames, isEligible: isMapDownloadEligible, submit: downloadSelectedMaps, toggle: toggleMapSelection } =
+    useMapDownloadSelection(maps);
 
 function mapSelected(map: MapData) {
     emit("map-selected", map);

--- a/src/renderer/components/navbar/Downloads.vue
+++ b/src/renderer/components/navbar/Downloads.vue
@@ -7,9 +7,21 @@ SPDX-License-Identifier: MIT
 <template>
     <PopOutPanel :open="modelValue">
         <Transition name="fade" mode="out-in">
-            <div v-if="allDownloads.length" class="downloads">
+            <div v-if="hasDownloads" class="downloads">
                 <TransitionGroup tag="div" name="downloads-list">
-                    <div v-for="download in limitedList" :key="download.name" class="downloads__download">
+                    <div v-for="download in mapDownloadQueue" :key="download.springName" class="downloads__download">
+                        <div class="downloads__info">
+                            <div class="downloads__name">{{ download.springName }}</div>
+                            <div class="downloads__status">
+                                {{
+                                    download.status === "downloading"
+                                        ? t("lobby.navbar.downloads.downloading")
+                                        : t("lobby.navbar.downloads.queued")
+                                }}
+                            </div>
+                        </div>
+                    </div>
+                    <div v-for="download in nonMapDownloads" :key="`${download.type}:${download.name}`" class="downloads__download">
                         <div class="downloads__info">
                             <div class="downloads__name">{{ download.name }}</div>
                             <div class="downloads__type">{{ download.type }}</div>
@@ -30,13 +42,8 @@ SPDX-License-Identifier: MIT
                         </template>
                     </div>
                 </TransitionGroup>
-                <Transition tag="div" name="fade" mode="out-in">
-                    <div class="flex-row flex-grow flex-center" v-if="allDownloads.length > limitedList.length">
-                        {{ t("lobby.navbar.downloads.moreDownloads", { count: allDownloads.length - limitedList.length }) }}
-                    </div>
-                </Transition>
             </div>
-            <div v-else class="flex-row flex-grow flex-center">{{ t("lobby.navbar.downloads.noDownloads") }}</div>
+            <div v-else class="downloads__empty">{{ t("lobby.navbar.downloads.noDownloads") }}</div>
         </Transition>
     </PopOutPanel>
 </template>
@@ -50,6 +57,7 @@ import Progress from "@renderer/components/common/Progress.vue";
 import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { MIN_DOWNLOAD_BYTES, useDownloadProgress } from "@renderer/composables/useDownloadProgress";
+import { downloadsStore } from "@renderer/store/downloads.store";
 
 const { t } = useTypedI18n();
 const { allDownloads, downloadPercent, progressText } = useDownloadProgress();
@@ -77,7 +85,9 @@ const toggleMessages = inject<Ref<(open?: boolean, userId?: number) => void>>("t
 const toggleFriends = inject<Ref<(open?: boolean) => void>>("toggleFriends")!;
 const toggleDownloads = inject<Ref<(open?: boolean) => void>>("toggleDownloads")!;
 
-const limitedList = computed(() => allDownloads.value.slice(0, 5));
+const mapDownloadQueue = computed(() => downloadsStore.mapDownloadQueue);
+const nonMapDownloads = computed(() => allDownloads.value.filter((download) => download.type !== "map"));
+const hasDownloads = computed(() => mapDownloadQueue.value.length > 0 || nonMapDownloads.value.length > 0);
 
 toggleDownloads.value = async (open?: boolean) => {
     if (open) {
@@ -90,15 +100,18 @@ toggleDownloads.value = async (open?: boolean) => {
 
 <style lang="scss" scoped>
 .downloads {
-    display: flex;
-    flex-direction: column;
+    height: 400px;
+    overflow-y: auto;
+
     &__info {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        gap: 15px;
     }
+
     &__download {
-        height: 85px;
+        min-height: 68px;
         width: 100%;
         display: flex;
         flex-direction: column;
@@ -107,16 +120,27 @@ toggleDownloads.value = async (open?: boolean) => {
         background: rgba(255, 255, 255, 0.03);
         gap: 5px;
     }
-    &__type {
+
+    &__name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__type,
+    &__status {
+        flex: none;
         text-transform: uppercase;
         font-size: 12px;
         font-weight: 700;
         color: rgba(255, 255, 255, 0.7);
     }
+
     &__detail {
         font-size: 11px;
         color: rgba(255, 255, 255, 0.6);
     }
+
     &__extracting {
         display: flex;
         align-items: center;
@@ -125,12 +149,17 @@ toggleDownloads.value = async (open?: boolean) => {
         color: rgba(255, 255, 255, 0.7);
         flex: 1;
     }
+
+    &__empty {
+        display: flex;
+        min-height: 160px;
+        align-items: center;
+        justify-content: center;
+    }
 }
 
-// Transition
 .downloads-list-move {
-    transition: all 0.2s ease;
-    transition-delay: 0.2s;
+    transition: transform 0.2s ease;
 }
 .downloads-list-enter-active,
 .downloads-list-leave-active {

--- a/src/renderer/components/navbar/DownloadsButton.vue
+++ b/src/renderer/components/navbar/DownloadsButton.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: MIT
         :class="{ pulse: isDownloading }"
     >
         <Icon :icon="download" :height="40" />
+        <span v-if="mapDownloadCount > 0" class="download-button__badge">{{ mapDownloadCount }}</span>
     </Button>
 </template>
 
@@ -21,14 +22,34 @@ import { computed } from "vue";
 
 import Button from "@renderer/components/controls/Button.vue";
 import { MIN_DOWNLOAD_BYTES, useDownloadProgress } from "@renderer/composables/useDownloadProgress";
+import { downloadsStore } from "@renderer/store/downloads.store";
 
 const { allDownloads, totalDownloadBytes } = useDownloadProgress();
 const isDownloading = computed(() => allDownloads.value.length > 0);
+const mapDownloadCount = computed(() => downloadsStore.mapDownloadQueue.length);
 </script>
 
 <style lang="scss" scoped>
 .download-button {
     position: relative;
+    &__badge {
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        background: #e85d04;
+        color: white;
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1;
+    }
+
     &:before {
         @extend .fullsize;
         width: calc(100% - 2px);

--- a/src/renderer/composables/useMapDownloadSelection.ts
+++ b/src/renderer/composables/useMapDownloadSelection.ts
@@ -17,11 +17,7 @@ type MapCatalog = readonly DownloadableMap[] | undefined;
 export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
     const selectedMapNames = ref(new Set<string>());
     const queuedMapNames = computed(() => new Set(downloadsStore.mapDownloadQueue.map((entry) => entry.springName)));
-    const selectedDownloadMapNames = computed(() =>
-        (maps.value ?? [])
-            .filter((map) => selectedMapNames.value.has(map.springName) && isEligible(map))
-            .map((map) => map.springName)
-    );
+    const selectedDownloadMapNames = computed(() => (maps.value ?? []).filter((map) => selectedMapNames.value.has(map.springName) && isEligible(map)).map((map) => map.springName));
 
     function isEligible(map: DownloadableMap) {
         return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);

--- a/src/renderer/composables/useMapDownloadSelection.ts
+++ b/src/renderer/composables/useMapDownloadSelection.ts
@@ -18,6 +18,7 @@ export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
     const selectedMapNames = ref(new Set<string>());
     const queuedMapNames = computed(() => new Set(downloadsStore.mapDownloadQueue.map((entry) => entry.springName)));
     const selectedDownloadMapNames = computed(() => (maps.value ?? []).filter((map) => selectedMapNames.value.has(map.springName) && isEligible(map)).map((map) => map.springName));
+    const eligibleMapNames = computed(() => (maps.value ?? []).filter(isEligible).map((map) => map.springName));
 
     function isEligible(map: DownloadableMap) {
         return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);
@@ -33,6 +34,14 @@ export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
         selectedMapNames.value = nextSelection;
     }
 
+    function selectAll() {
+        selectedMapNames.value = new Set(eligibleMapNames.value);
+    }
+
+    function clearSelection() {
+        selectedMapNames.value = new Set();
+    }
+
     function submit() {
         queueMapDownloads(selectedDownloadMapNames.value);
         selectedMapNames.value = new Set();
@@ -43,6 +52,8 @@ export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
         selectedDownloadMapNames,
         isEligible,
         toggle,
+        selectAll,
+        clearSelection,
         submit,
     };
 }

--- a/src/renderer/composables/useMapDownloadSelection.ts
+++ b/src/renderer/composables/useMapDownloadSelection.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { computed, ref, type Ref } from "vue";
+
+import type { MapData } from "@main/content/maps/map-data";
+import { downloadsStore } from "@renderer/store/downloads.store";
+import { mapsStore, queueMapDownloads } from "@renderer/store/maps.store";
+
+type MapCatalog = readonly MapData[] | undefined;
+
+/**
+ * Owns map-catalog download selection while retaining the catalog's visible order for batch submission.
+ */
+export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
+    const selectedMapNames = ref(new Set<string>());
+    const queuedMapNames = computed(() => new Set(downloadsStore.mapDownloadQueue.map((entry) => entry.springName)));
+    const selectedDownloadMapNames = computed(() =>
+        (maps.value ?? [])
+            .filter((map) => selectedMapNames.value.has(map.springName) && isEligible(map))
+            .map((map) => map.springName)
+    );
+
+    function isEligible(map: MapData) {
+        return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);
+    }
+
+    function toggle(springName: string) {
+        const nextSelection = new Set(selectedMapNames.value);
+        if (nextSelection.has(springName)) {
+            nextSelection.delete(springName);
+        } else {
+            nextSelection.add(springName);
+        }
+        selectedMapNames.value = nextSelection;
+    }
+
+    function submit() {
+        queueMapDownloads(selectedDownloadMapNames.value);
+        selectedMapNames.value = new Set();
+    }
+
+    return {
+        selectedMapNames,
+        selectedDownloadMapNames,
+        isEligible,
+        toggle,
+        submit,
+    };
+}

--- a/src/renderer/composables/useMapDownloadSelection.ts
+++ b/src/renderer/composables/useMapDownloadSelection.ts
@@ -8,7 +8,8 @@ import type { MapData } from "@main/content/maps/map-data";
 import { downloadsStore } from "@renderer/store/downloads.store";
 import { mapsStore, queueMapDownloads } from "@renderer/store/maps.store";
 
-type MapCatalog = readonly MapData[] | undefined;
+type DownloadableMap = Pick<MapData, "springName" | "isInstalled">;
+type MapCatalog = readonly DownloadableMap[] | undefined;
 
 /**
  * Owns map-catalog download selection while retaining the catalog's visible order for batch submission.
@@ -22,7 +23,7 @@ export function useMapDownloadSelection(maps: Ref<MapCatalog>) {
             .map((map) => map.springName)
     );
 
-    function isEligible(map: MapData) {
+    function isEligible(map: DownloadableMap) {
         return !map.isInstalled && !mapsStore.availableMapNames.has(map.springName) && !queuedMapNames.value.has(map.springName);
     }
 

--- a/src/renderer/store/downloads.store.ts
+++ b/src/renderer/store/downloads.store.ts
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 import { DownloadInfo } from "@main/content/downloads";
+import type { MapDownloadQueueEntry } from "@main/content/maps/map-content";
 import { reactive } from "vue";
 
 export const downloadsStore: {
     isInitialized: boolean;
+    mapDownloadQueue: MapDownloadQueueEntry[];
     mapDownloads: DownloadInfo[];
     engineDownloads: DownloadInfo[];
     gameDownloads: DownloadInfo[];
@@ -16,6 +18,7 @@ export const downloadsStore: {
     isPathChanging: boolean;
 } = reactive({
     isInitialized: false,
+    mapDownloadQueue: [],
     mapDownloads: [],
     engineDownloads: [],
     gameDownloads: [],
@@ -25,7 +28,12 @@ export const downloadsStore: {
     isPathChanging: false,
 });
 
-export function initDownloadsStore() {
+export async function initDownloadsStore() {
+    window.maps.onDownloadQueueChanged((queue) => {
+        downloadsStore.mapDownloadQueue = queue;
+    });
+    downloadsStore.mapDownloadQueue = await window.maps.getDownloadQueue();
+
     window.downloads.onDownloadMapStart((downloadInfo) => {
         console.debug("Download started", downloadInfo);
         downloadsStore.mapDownloads.push({ ...downloadInfo });

--- a/src/renderer/store/maps.store.ts
+++ b/src/renderer/store/maps.store.ts
@@ -154,6 +154,15 @@ async function fetchMapImages(map: MapData) {
     console.debug("Updated map images ", map.springName);
 }
 
+export function queueMapDownloads(springNames: string[]) {
+    if (springNames.length === 0) return;
+
+    void window.maps.downloadMaps(springNames).catch((error) => {
+        console.error("Failed to download selected maps", error);
+        notificationsApi.alert({ text: "Map download failed.", severity: "error" });
+    });
+}
+
 //TODO: the MapsAPI already includes a multiple-map version request we can use to extend this
 export async function downloadMap(springName: string) {
     let dbDelegate: EntityTable<MapData, "springName"> | EntityTable<MapDownloadData, "springName"> = db.maps;

--- a/tests/unit/main/content/maps/map-content.spec.ts
+++ b/tests/unit/main/content/maps/map-content.spec.ts
@@ -2,23 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { settings } = vi.hoisted(() => ({
-    settings: { devMode: false },
-}));
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@main/config/app", () => ({
     getAssetsPath: () => "/tmp/bar-lobby-assets",
     getCaCertPath: () => undefined,
     getEnginePath: () => "/tmp/bar-lobby-engines",
     getMapsPaths: () => ["/tmp/bar-lobby-maps"],
-}));
-
-vi.mock("@main/services/settings.service", () => ({
-    settingsService: {
-        getSettings: () => settings,
-    },
 }));
 
 import { MapContentAPI } from "@main/content/maps/map-content";
@@ -59,33 +49,6 @@ async function flushQueue() {
 }
 
 describe("MapContentAPI download queue", () => {
-    beforeEach(() => {
-        settings.devMode = false;
-    });
-
-    it("holds a dev-mode map as downloading before starting pr-downloader", async () => {
-        vi.useFakeTimers();
-        settings.devMode = true;
-        try {
-            const maps = new ControlledMapContentAPI();
-            const download = maps.downloadMap("map-a");
-
-            expect(maps.getMapDownloadQueue()).toEqual([{ springName: "map-a", status: "downloading" }]);
-            expect(maps.started).toEqual([]);
-
-            await vi.advanceTimersByTimeAsync(2999);
-            expect(maps.started).toEqual([]);
-
-            await vi.advanceTimersByTimeAsync(1);
-            expect(maps.started).toEqual(["map-a"]);
-
-            maps.complete("map-a");
-            await expect(download).resolves.toBeUndefined();
-        } finally {
-            vi.useRealTimers();
-        }
-    });
-
     it("reports the active map first and preserves waiting queue order", async () => {
         const maps = new ControlledMapContentAPI();
         const queueChanges: unknown[] = [];

--- a/tests/unit/main/content/maps/map-content.spec.ts
+++ b/tests/unit/main/content/maps/map-content.spec.ts
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { settings } = vi.hoisted(() => ({
+    settings: { devMode: false },
+}));
+
+vi.mock("@main/config/app", () => ({
+    getAssetsPath: () => "/tmp/bar-lobby-assets",
+    getCaCertPath: () => undefined,
+    getEnginePath: () => "/tmp/bar-lobby-engines",
+    getMapsPaths: () => ["/tmp/bar-lobby-maps"],
+}));
+
+vi.mock("@main/services/settings.service", () => ({
+    settingsService: {
+        getSettings: () => settings,
+    },
+}));
+
+import { MapContentAPI } from "@main/content/maps/map-content";
+import type { DownloadInfo } from "@main/content/downloads";
+
+type PendingDownload = {
+    resolve: (download: DownloadInfo) => void;
+    reject: (error: Error) => void;
+};
+
+class ControlledMapContentAPI extends MapContentAPI {
+    public readonly started: string[] = [];
+    private readonly pending = new Map<string, PendingDownload>();
+
+    public override isVersionInstalled() {
+        return false;
+    }
+
+    public complete(springName: string) {
+        this.pending.get(springName)?.resolve({ type: "map", name: springName, currentBytes: 1, totalBytes: 1, progress: 1 });
+    }
+
+    public fail(springName: string, error: Error) {
+        this.pending.get(springName)?.reject(error);
+    }
+
+    protected override downloadContent(_type: "game" | "map", springName: string): Promise<DownloadInfo> {
+        this.started.push(springName);
+        return new Promise<DownloadInfo>((resolve, reject) => {
+            this.pending.set(springName, { resolve, reject });
+        });
+    }
+}
+
+async function flushQueue() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("MapContentAPI download queue", () => {
+    beforeEach(() => {
+        settings.devMode = false;
+    });
+
+    it("holds a dev-mode map as downloading before starting pr-downloader", async () => {
+        vi.useFakeTimers();
+        settings.devMode = true;
+        try {
+            const maps = new ControlledMapContentAPI();
+            const download = maps.downloadMap("map-a");
+
+            expect(maps.getMapDownloadQueue()).toEqual([{ springName: "map-a", status: "downloading" }]);
+            expect(maps.started).toEqual([]);
+
+            await vi.advanceTimersByTimeAsync(2999);
+            expect(maps.started).toEqual([]);
+
+            await vi.advanceTimersByTimeAsync(1);
+            expect(maps.started).toEqual(["map-a"]);
+
+            maps.complete("map-a");
+            await expect(download).resolves.toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("reports the active map first and preserves waiting queue order", async () => {
+        const maps = new ControlledMapContentAPI();
+        const queueChanges: unknown[] = [];
+        maps.onMapDownloadQueueChanged.add((queue) => queueChanges.push(queue));
+
+        const batch = maps.downloadMaps(["map-a", "map-b", "map-c"]);
+
+        expect(maps.getMapDownloadQueue()).toEqual([
+            { springName: "map-a", status: "downloading" },
+            { springName: "map-b", status: "queued" },
+            { springName: "map-c", status: "queued" },
+        ]);
+
+        maps.complete("map-a");
+        await flushQueue();
+
+        expect(maps.getMapDownloadQueue()).toEqual([
+            { springName: "map-b", status: "downloading" },
+            { springName: "map-c", status: "queued" },
+        ]);
+        expect(queueChanges).toContainEqual([
+            { springName: "map-b", status: "downloading" },
+            { springName: "map-c", status: "queued" },
+        ]);
+
+        maps.complete("map-b");
+        await flushQueue();
+        maps.complete("map-c");
+        await expect(batch).resolves.toEqual([undefined, undefined, undefined]);
+    });
+
+    it("appends a later batch behind the active batch", async () => {
+        const maps = new ControlledMapContentAPI();
+
+        const firstBatch = maps.downloadMaps(["map-a", "map-b"]);
+        const laterBatch = maps.downloadMaps(["map-c"]);
+
+        expect(maps.started).toEqual(["map-a"]);
+
+        maps.complete("map-a");
+        await flushQueue();
+        expect(maps.started).toEqual(["map-a", "map-b"]);
+
+        maps.complete("map-b");
+        await flushQueue();
+        expect(maps.started).toEqual(["map-a", "map-b", "map-c"]);
+
+        maps.complete("map-c");
+        await expect(firstBatch).resolves.toEqual([undefined, undefined]);
+        await expect(laterBatch).resolves.toEqual([undefined]);
+    });
+
+    it("queues a batch behind an active single-map request", async () => {
+        const maps = new ControlledMapContentAPI();
+
+        const first = maps.downloadMap("map-a");
+        const batch = maps.downloadMaps(["map-b", "map-c"]);
+
+        expect(maps.started).toEqual(["map-a"]);
+
+        maps.complete("map-a");
+        await flushQueue();
+        expect(maps.started).toEqual(["map-a", "map-b"]);
+
+        maps.complete("map-b");
+        await flushQueue();
+        maps.complete("map-c");
+
+        await expect(first).resolves.toBeUndefined();
+        await expect(batch).resolves.toEqual([undefined, undefined]);
+    });
+
+    it("continues with the next queued map after a download fails", async () => {
+        const maps = new ControlledMapContentAPI();
+        const failure = new Error("map-a failed");
+        const batch = maps.downloadMaps(["map-a", "map-b"]);
+
+        expect(maps.started).toEqual(["map-a"]);
+
+        maps.fail("map-a", failure);
+        await expect(batch).rejects.toThrow(failure);
+        await flushQueue();
+        expect(maps.started).toEqual(["map-a", "map-b"]);
+
+        maps.complete("map-b");
+    });
+
+    it("does not start the same map more than once while it is active or queued", async () => {
+        const maps = new ControlledMapContentAPI();
+
+        const first = maps.downloadMap("map-a");
+        const duplicateAndLaterMap = maps.downloadMaps(["map-a", "map-b"]);
+
+        expect(maps.started).toEqual(["map-a"]);
+
+        maps.complete("map-a");
+        await flushQueue();
+        expect(maps.started).toEqual(["map-a", "map-b"]);
+
+        maps.complete("map-b");
+        await expect(first).resolves.toBeUndefined();
+        await expect(duplicateAndLaterMap).resolves.toEqual([undefined, undefined]);
+    });
+});

--- a/tests/unit/main/content/maps/map-download-queue.spec.ts
+++ b/tests/unit/main/content/maps/map-download-queue.spec.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+
+import { MapDownloadQueue } from "@main/content/maps/map-download-queue";
+
+type Deferred = {
+    resolve: () => void;
+};
+
+async function flushQueue() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("MapDownloadQueue", () => {
+    it("owns FIFO state and exposes only ordered queue snapshots", async () => {
+        const started: string[] = [];
+        const pending = new Map<string, Deferred>();
+        const queue = new MapDownloadQueue((springName) => {
+            started.push(springName);
+            return new Promise<void>((resolve) => pending.set(springName, { resolve }));
+        });
+
+        const first = queue.enqueue("map-a");
+        const duplicate = queue.enqueue("map-a");
+        const second = queue.enqueue("map-b");
+
+        expect(duplicate).toBe(first);
+        expect(started).toEqual(["map-a"]);
+        expect(queue.getSnapshot()).toEqual([
+            { springName: "map-a", status: "downloading" },
+            { springName: "map-b", status: "queued" },
+        ]);
+
+        pending.get("map-a")?.resolve();
+        await flushQueue();
+
+        expect(started).toEqual(["map-a", "map-b"]);
+        expect(queue.getSnapshot()).toEqual([{ springName: "map-b", status: "downloading" }]);
+
+        pending.get("map-b")?.resolve();
+        await expect(Promise.all([first, duplicate, second])).resolves.toEqual([undefined, undefined, undefined]);
+    });
+});

--- a/tests/unit/renderer/components/maps/map-list-component.spec.ts
+++ b/tests/unit/renderer/components/maps/map-list-component.spec.ts
@@ -55,8 +55,9 @@ describe("MapListComponent", () => {
             global: {
                 stubs: {
                     Button: {
+                        props: ["disabled"],
                         emits: ["click"],
-                        template: '<button :class="$attrs.class" @click="$emit(\'click\')"><slot /></button>',
+                        template: '<button :class="$attrs.class" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
                     },
                     Checkbox: {
                         props: ["modelValue"],
@@ -86,8 +87,9 @@ describe("MapListComponent", () => {
             global: {
                 stubs: {
                     Button: {
+                        props: ["disabled"],
                         emits: ["click"],
-                        template: '<button :class="$attrs.class" @click="$emit(\'click\')"><slot /></button>',
+                        template: '<button :class="$attrs.class" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
                     },
                     Checkbox: {
                         props: ["modelValue"],
@@ -105,5 +107,35 @@ describe("MapListComponent", () => {
         await wrapper.find(".download-selected").trigger("click");
 
         expect(queueMapDownloads).toHaveBeenCalledWith(["map-b", "map-a"]);
+    });
+
+    it("clears an all-map selection without submitting any downloads", async () => {
+        const wrapper = mount(MapListComponent, {
+            global: {
+                stubs: {
+                    Button: {
+                        props: ["disabled"],
+                        emits: ["click"],
+                        template: '<button :class="$attrs.class" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+                    },
+                    Checkbox: {
+                        props: ["modelValue"],
+                        emits: ["update:modelValue"],
+                        template: '<button class="map-checkbox" @click="$emit(\'update:modelValue\', !modelValue)"></button>',
+                    },
+                    MapOverviewCard: { template: "<div />" },
+                    SearchBox: { template: "<div />" },
+                    Select: { template: "<div />" },
+                },
+            },
+        });
+
+        await wrapper.find(".select-all-maps").trigger("click");
+        expect(wrapper.find(".download-selected").attributes("disabled")).toBeUndefined();
+
+        await wrapper.find(".clear-all-maps").trigger("click");
+
+        expect(wrapper.find(".download-selected").attributes("disabled")).toBeDefined();
+        expect(queueMapDownloads).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/renderer/components/maps/map-list-component.spec.ts
+++ b/tests/unit/renderer/components/maps/map-list-component.spec.ts
@@ -56,7 +56,7 @@ describe("MapListComponent", () => {
                 stubs: {
                     Button: {
                         emits: ["click"],
-                        template: '<button class="download-selected" @click="$emit(\'click\')"><slot /></button>',
+                        template: '<button :class="$attrs.class" @click="$emit(\'click\')"><slot /></button>',
                     },
                     Checkbox: {
                         props: ["modelValue"],
@@ -76,6 +76,32 @@ describe("MapListComponent", () => {
         await checkboxes[1].trigger("click");
         await checkboxes[0].trigger("click");
         await nextTick();
+        await wrapper.find(".download-selected").trigger("click");
+
+        expect(queueMapDownloads).toHaveBeenCalledWith(["map-b", "map-a"]);
+    });
+
+    it("selects every displayed eligible map before submitting the batch", async () => {
+        const wrapper = mount(MapListComponent, {
+            global: {
+                stubs: {
+                    Button: {
+                        emits: ["click"],
+                        template: '<button :class="$attrs.class" @click="$emit(\'click\')"><slot /></button>',
+                    },
+                    Checkbox: {
+                        props: ["modelValue"],
+                        emits: ["update:modelValue"],
+                        template: '<button class="map-checkbox" @click="$emit(\'update:modelValue\', !modelValue)"></button>',
+                    },
+                    MapOverviewCard: { template: "<div />" },
+                    SearchBox: { template: "<div />" },
+                    Select: { template: "<div />" },
+                },
+            },
+        });
+
+        await wrapper.find(".select-all-maps").trigger("click");
         await wrapper.find(".download-selected").trigger("click");
 
         expect(queueMapDownloads).toHaveBeenCalledWith(["map-b", "map-a"]);

--- a/tests/unit/renderer/components/maps/map-list-component.spec.ts
+++ b/tests/unit/renderer/components/maps/map-list-component.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+import MapListComponent from "@renderer/components/maps/MapListComponent.vue";
+
+const { queueMapDownloads } = vi.hoisted(() => ({ queueMapDownloads: vi.fn() }));
+
+vi.mock("@renderer/composables/useDexieLiveQuery", async () => {
+    const { ref } = await import("vue");
+    return {
+        useDexieLiveQueryWithDeps: () =>
+            ref([
+                { springName: "map-b", isInstalled: false },
+                { springName: "map-installed", isInstalled: true },
+                { springName: "map-a", isInstalled: false },
+                { springName: "map-queued", isInstalled: false },
+            ]),
+    };
+});
+
+vi.mock("@renderer/store/db", () => ({ db: {} }));
+vi.mock("@renderer/store/maps.store", () => ({
+    mapsStore: {
+        availableMapNames: new Set<string>(),
+        filters: {
+            downloadedOnly: false,
+            favoritesOnly: false,
+            gameType: {},
+            maxPlayers: 40,
+            minPlayers: 2,
+            terrain: {},
+        },
+    },
+    queueMapDownloads,
+}));
+vi.mock("@renderer/store/downloads.store", () => ({
+    downloadsStore: {
+        mapDownloadQueue: [{ springName: "map-queued", status: "queued" }],
+    },
+}));
+vi.mock("@vueuse/core", () => ({ useInfiniteScroll: vi.fn() }));
+
+describe("MapListComponent", () => {
+    beforeEach(() => {
+        queueMapDownloads.mockReset();
+    });
+
+    it("submits selected eligible maps in their displayed catalog order", async () => {
+        const wrapper = mount(MapListComponent, {
+            global: {
+                stubs: {
+                    Button: {
+                        emits: ["click"],
+                        template: '<button class="download-selected" @click="$emit(\'click\')"><slot /></button>',
+                    },
+                    Checkbox: {
+                        props: ["modelValue"],
+                        emits: ["update:modelValue"],
+                        template: '<button class="map-checkbox" @click="$emit(\'update:modelValue\', !modelValue)"></button>',
+                    },
+                    MapOverviewCard: { template: "<div />" },
+                    SearchBox: { template: "<div />" },
+                    Select: { template: "<div />" },
+                },
+            },
+        });
+
+        const checkboxes = wrapper.findAll(".map-checkbox");
+        expect(checkboxes).toHaveLength(2);
+
+        await checkboxes[1].trigger("click");
+        await checkboxes[0].trigger("click");
+        await nextTick();
+        await wrapper.find(".download-selected").trigger("click");
+
+        expect(queueMapDownloads).toHaveBeenCalledWith(["map-b", "map-a"]);
+    });
+});

--- a/tests/unit/renderer/components/navbar/downloads-button.spec.ts
+++ b/tests/unit/renderer/components/navbar/downloads-button.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+import DownloadsButton from "@renderer/components/navbar/DownloadsButton.vue";
+import { downloadsStore } from "@renderer/store/downloads.store";
+
+describe("DownloadsButton", () => {
+    beforeEach(() => {
+        downloadsStore.mapDownloadQueue = [];
+        downloadsStore.mapDownloads = [];
+        downloadsStore.engineDownloads = [];
+        downloadsStore.gameDownloads = [];
+        downloadsStore.updateDownloads = [];
+    });
+
+    it("shows a badge with the combined queued and downloading map count", async () => {
+        const wrapper = mount(DownloadsButton, {
+            global: {
+                stubs: {
+                    Button: { template: '<button :class="$attrs.class"><slot /></button>' },
+                    Icon: { template: "<div />" },
+                },
+            },
+        });
+
+        expect(wrapper.find(".download-button__badge").exists()).toBe(false);
+
+        downloadsStore.mapDownloadQueue = [
+            { springName: "map-downloading", status: "downloading" },
+            { springName: "map-queued-a", status: "queued" },
+            { springName: "map-queued-b", status: "queued" },
+        ];
+        await nextTick();
+
+        expect(wrapper.find(".download-button__badge").text()).toBe("3");
+    });
+});

--- a/tests/unit/renderer/components/navbar/downloads.spec.ts
+++ b/tests/unit/renderer/components/navbar/downloads.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref } from "vue";
+
+import Downloads from "@renderer/components/navbar/Downloads.vue";
+import PopOutPanel from "@renderer/components/navbar/PopOutPanel.vue";
+import { downloadsStore } from "@renderer/store/downloads.store";
+
+vi.mock("@renderer/i18n", () => ({
+    useTypedI18n: () => ({
+        t: (key: string) =>
+            ({
+                "lobby.navbar.downloads.downloading": "Downloading",
+                "lobby.navbar.downloads.queued": "Queued",
+                "lobby.navbar.downloads.noDownloads": "No downloads active",
+            })[key] ?? key,
+    }),
+}));
+
+describe("Downloads", () => {
+    beforeEach(() => {
+        downloadsStore.mapDownloadQueue = [];
+        downloadsStore.mapDownloads = [];
+        downloadsStore.engineDownloads = [];
+        downloadsStore.gameDownloads = [];
+        downloadsStore.updateDownloads = [];
+    });
+
+    it("declares a transform transition so completed rows animate the remaining queue upward", () => {
+        const source = readFileSync(resolve(process.cwd(), "src/renderer/components/navbar/Downloads.vue"), "utf8");
+
+        expect(source).toContain(".downloads-list-move {\n    transition: transform 0.2s ease;");
+    });
+
+    it("keeps the navbar popover and renders the ordered map queue without progress details", () => {
+        downloadsStore.mapDownloadQueue = [
+            { springName: "map-a", status: "downloading" },
+            { springName: "map-b", status: "queued" },
+            { springName: "map-c", status: "queued" },
+        ];
+
+        const wrapper = mount(Downloads, {
+            props: { modelValue: true },
+            global: {
+                provide: {
+                    toggleDownloads: ref(),
+                    toggleFriends: ref(),
+                    toggleMessages: ref(),
+                },
+                stubs: {
+                    Loader: { template: "<div />" },
+                    Panel: { template: '<div class="popout-panel"><slot /></div>' },
+                    Progress: { template: "<div />" },
+                },
+            },
+        });
+
+        expect(wrapper.findComponent(PopOutPanel).exists()).toBe(true);
+        expect(wrapper.findAll(".downloads__download").map((row) => row.text())).toEqual(["map-aDownloading", "map-bQueued", "map-cQueued"]);
+        expect(wrapper.text()).not.toContain("%");
+    });
+});

--- a/tests/unit/renderer/composables/use-map-download-selection.spec.ts
+++ b/tests/unit/renderer/composables/use-map-download-selection.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { useMapDownloadSelection } from "@renderer/composables/useMapDownloadSelection";
+
+const { queueMapDownloads } = vi.hoisted(() => ({ queueMapDownloads: vi.fn() }));
+
+vi.mock("@renderer/store/maps.store", () => ({
+    mapsStore: { availableMapNames: new Set<string>() },
+    queueMapDownloads,
+}));
+vi.mock("@renderer/store/downloads.store", () => ({
+    downloadsStore: {
+        mapDownloadQueue: [{ springName: "map-queued", status: "queued" }],
+    },
+}));
+
+describe("useMapDownloadSelection", () => {
+    it("submits selected eligible maps in their catalog order and clears the selection", () => {
+        const maps = ref([
+            { springName: "map-b", isInstalled: false },
+            { springName: "map-installed", isInstalled: true },
+            { springName: "map-a", isInstalled: false },
+            { springName: "map-queued", isInstalled: false },
+        ]);
+        const selection = useMapDownloadSelection(maps);
+
+        selection.toggle("map-a");
+        selection.toggle("map-b");
+        selection.submit();
+
+        expect(queueMapDownloads).toHaveBeenCalledWith(["map-b", "map-a"]);
+        expect(selection.selectedMapNames.value).toEqual(new Set());
+    });
+});


### PR DESCRIPTION
**READ: #635 MUST be merged first! This PR is stacked**

Adds a badge to the existing Downloads navbar button showing the current number of map downloads that are queued or actively downloading. The badge is hidden when the map queue is empty, while the button’s existing progress styling and popover behavior remain unchanged.

_AI disclosure: investigation, initial implementation. Codex Terra 5.6_