### PR TITLE
Fix stale bot-option updates after participant removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules
 dist
 .vite
-.testclient
 
 # Game state+assets
 /assets*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.testclient
 .DS_Store
 node_modules
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.testclient
 .DS_Store
 node_modules
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 dist
 .vite
+.testclient
 
 # Game state+assets
 /assets*

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -442,8 +442,7 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot",
-                    "faction": "Faction"
+                    "configureBot": "Configure Bot"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -442,7 +442,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "optionsNotApplied": "This bot was removed while you were configuring its options. Your changes were not applied."
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -442,7 +442,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2425,8 +2425,7 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null,
-                    "faction": null
+                    "configureBot": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2425,7 +2425,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "optionsNotApplied": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2425,7 +2425,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2296,7 +2296,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2296,7 +2296,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "optionsNotApplied": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2296,8 +2296,7 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null,
-                    "faction": null
+                    "configureBot": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2273,8 +2273,7 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot",
-                    "faction": "Faction"
+                    "configureBot": "Configure Bot"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2273,7 +2273,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "optionsNotApplied": "This bot was removed while you were configuring its options. Your changes were not applied."
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2273,7 +2273,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4278,7 +4278,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "optionsNotApplied": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4278,8 +4278,7 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null,
-                    "faction": null
+                    "configureBot": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4278,7 +4278,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4247,7 +4247,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "optionsNotApplied": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4247,7 +4247,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4247,8 +4247,7 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null,
-                    "faction": null
+                    "configureBot": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4389,8 +4389,7 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null,
-                    "faction": null
+                    "configureBot": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4389,7 +4389,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "optionsNotApplied": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4389,7 +4389,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -12,7 +12,31 @@ SPDX-License-Identifier: MIT
                 <Icon v-else-if="isScavenger(bot)" :icon="robotAngry" />
                 <Icon v-else :icon="robot" />
             </div>
-            <div>{{ bot.name }}</div>
+            <div class="bot-name">{{ bot.name }}</div>
+            <div v-if="hasInlineControls" class="bot-controls">
+                <label class="bot-control">
+                    <span>{{ t("lobby.components.battle.botParticipant.faction") }}</span>
+                    <Select
+                        data-test="bot-faction"
+                        :modelValue="bot.faction"
+                        :options="factionOptions"
+                        optionLabel="name"
+                        optionValue="value"
+                        @update:model-value="setBotFaction"
+                    />
+                </label>
+                <label v-if="difficultyOption" class="bot-control">
+                    <span>{{ difficultyOption.name }}</span>
+                    <Select
+                        data-test="bot-difficulty"
+                        :modelValue="bot.aiOptions[difficultyOption.key] ?? difficultyOption.default"
+                        :options="difficultyOption.options"
+                        optionLabel="name"
+                        optionValue="key"
+                        @update:model-value="setDifficulty"
+                    />
+                </label>
+            </div>
         </TeamParticipant>
         <LuaOptionsModal
             :id="`configure-bot-${bot.name}`"

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -12,31 +12,7 @@ SPDX-License-Identifier: MIT
                 <Icon v-else-if="isScavenger(bot)" :icon="robotAngry" />
                 <Icon v-else :icon="robot" />
             </div>
-            <div class="bot-name">{{ bot.name }}</div>
-            <div v-if="hasInlineControls" class="bot-controls">
-                <label class="bot-control">
-                    <span>{{ t("lobby.components.battle.botParticipant.faction") }}</span>
-                    <Select
-                        data-test="bot-faction"
-                        :modelValue="bot.faction"
-                        :options="factionOptions"
-                        optionLabel="name"
-                        optionValue="value"
-                        @update:model-value="setBotFaction"
-                    />
-                </label>
-                <label v-if="difficultyOption" class="bot-control">
-                    <span>{{ difficultyOption.name }}</span>
-                    <Select
-                        data-test="bot-difficulty"
-                        :modelValue="bot.aiOptions[difficultyOption.key] ?? difficultyOption.default"
-                        :options="difficultyOption.options"
-                        optionLabel="name"
-                        optionValue="key"
-                        @update:model-value="setDifficulty"
-                    />
-                </label>
-            </div>
+            <div>{{ bot.name }}</div>
         </TeamParticipant>
         <LuaOptionsModal
             :id="`configure-bot-${bot.name}`"

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -38,6 +38,7 @@ import TeamParticipant from "@renderer/components/battle/TeamParticipant.vue";
 import { LuaOptionSection } from "@main/content/game/lua-options";
 import { Bot, isRaptor, isScavenger } from "@main/game/battle/battle-types";
 import ContextMenu from "primevue/contextmenu";
+import { notificationsApi } from "@renderer/api/notifications";
 import { battleActions } from "@renderer/store/battle.store";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
@@ -94,6 +95,10 @@ async function configureBot() {
 
 function setBotOptions(options: Record<string, unknown>) {
     if (!battleActions.updateBotOptions(props.bot, options)) {
+        notificationsApi.alert({
+            text: t("lobby.components.battle.botParticipant.optionsNotApplied"),
+            severity: "warning",
+        });
         botOptionsOpen.value = false;
     }
 }

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -93,7 +93,9 @@ async function configureBot() {
 }
 
 function setBotOptions(options: Record<string, unknown>) {
-    battleActions.updateBotOptions(props.bot, options);
+    if (!battleActions.updateBotOptions(props.bot, options)) {
+        botOptionsOpen.value = false;
+    }
 }
 </script>
 

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -183,9 +183,11 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
         .filter((p) => isBot(p))
         .find((p) => p.id === bot.id);
     if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+        return false;
     }
-    bot.aiOptions = options;
+
+    foundBot.aiOptions = options;
+    return true;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -161,7 +161,6 @@ function addBot(ai: EngineAI | GameAI, teamId: number) {
         name: ai.name,
         aiOptions: {},
         aiShortName: ai.shortName,
-        faction: Faction.Armada,
         host: battleStore.me.id,
     } satisfies Bot);
 }
@@ -189,16 +188,6 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
     }
 
     foundBot.aiOptions = options;
-    return true;
-}
-
-function updateBotFaction(bot: Bot, faction: Faction | undefined) {
-    const foundBot = findBot(bot);
-    if (!foundBot) {
-        return false;
-    }
-
-    foundBot.faction = faction;
     return true;
 }
 

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -177,16 +177,30 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
-function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = battleStore.teams
+function findBot(bot: Bot) {
+    return battleStore.teams
         .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
+        .filter((participant) => isBot(participant))
+        .find((participant) => participant.id === bot.id);
+}
+
+function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
+    const foundBot = findBot(bot);
     if (!foundBot) {
         return false;
     }
 
     foundBot.aiOptions = options;
+    return true;
+}
+
+function updateBotFaction(bot: Bot, faction: Faction | undefined) {
+    const foundBot = findBot(bot);
+    if (!foundBot) {
+        return false;
+    }
+
+    foundBot.faction = faction;
     return true;
 }
 

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -161,6 +161,7 @@ function addBot(ai: EngineAI | GameAI, teamId: number) {
         name: ai.name,
         aiOptions: {},
         aiShortName: ai.shortName,
+        faction: Faction.Armada,
         host: battleStore.me.id,
     } satisfies Bot);
 }
@@ -178,10 +179,7 @@ function duplicateBot(bot: Bot, teamId: number) {
 }
 
 function findBot(bot: Bot) {
-    return battleStore.teams
-        .flat()
-        .filter((participant) => isBot(participant))
-        .find((participant) => participant.id === bot.id);
+    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
 }
 
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {


### PR DESCRIPTION
Prevent the offline battle renderer from throwing when an open bot Configure modal submits options after its bot has been removed during team reconciliation. 

**The update now targets the resolved live participant** if it no longer exists, the stale update is safely ignored and the obsolete modal closes. Closes #642.