### PR TITLE
feat: surface bot faction and difficulty controls in participant rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.testclient
 .DS_Store
 node_modules
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.testclient
 .DS_Store
 node_modules
 dist

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -442,7 +442,9 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction",
+                    "defaultFaction": "Default"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -442,7 +442,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/main/game/battle/battle-types.ts
+++ b/src/main/game/battle/battle-types.ts
@@ -134,7 +134,7 @@ export type Bot = {
     name: string;
     aiOptions: Record<string, unknown>;
 
-    faction?: Faction;
+    faction: Faction;
     startPos?: { x: number; z: number };
     handicap?: number;
     advantage?: number;

--- a/src/main/game/battle/bot-options.ts
+++ b/src/main/game/battle/bot-options.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { LuaOptionList } from "@main/content/game/lua-options";
+
+import { Faction } from "./battle-types";
+
+export const botFactionOptions = [
+    { name: Faction.Armada, value: Faction.Armada },
+    { name: Faction.Cortex, value: Faction.Cortex },
+];
+
+export const barbProfileOptions: LuaOptionList["options"] = [
+    { key: "hard_aggressive", name: "Hard | Aggressive", type: "list" },
+    { key: "hard", name: "Hard | Balanced", type: "list" },
+    { key: "medium", name: "Medium | Lazy", type: "list" },
+    { key: "easy", name: "Easy | Slow", type: "list" },
+    { key: "dev", name: "Testing AI", type: "list" },
+];

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2425,7 +2425,9 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null,
+                    "defaultFaction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2425,7 +2425,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2296,7 +2296,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2296,7 +2296,9 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null,
+                    "defaultFaction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2273,7 +2273,9 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction",
+                    "defaultFaction": "Default"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2273,7 +2273,8 @@
                     "configure": "Configure",
                     "duplicate": "Duplicate",
                     "kick": "Kick",
-                    "configureBot": "Configure Bot"
+                    "configureBot": "Configure Bot",
+                    "faction": "Faction"
                 },
                 "addBotModal": {
                     "title": "Add Bot"

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4278,7 +4278,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4278,7 +4278,9 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null,
+                    "defaultFaction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4247,7 +4247,9 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null,
+                    "defaultFaction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4247,7 +4247,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4389,7 +4389,8 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4389,7 +4389,9 @@
                     "configure": null,
                     "duplicate": null,
                     "kick": null,
-                    "configureBot": null
+                    "configureBot": null,
+                    "faction": null,
+                    "defaultFaction": null
                 },
                 "addBotModal": {
                     "title": null

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -129,7 +129,9 @@ async function configureBot() {
 }
 
 function setBotOptions(options: Record<string, unknown>) {
-    battleActions.updateBotOptions(props.bot, options);
+    if (!battleActions.updateBotOptions(props.bot, options)) {
+        botOptionsOpen.value = false;
+    }
 }
 
 function setBotFaction(faction: Faction | undefined) {

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -12,7 +12,31 @@ SPDX-License-Identifier: MIT
                 <Icon v-else-if="isScavenger(bot)" :icon="robotAngry" />
                 <Icon v-else :icon="robot" />
             </div>
-            <div>{{ bot.name }}</div>
+            <div class="bot-name">{{ bot.name }}</div>
+            <div v-if="hasInlineControls" class="bot-controls">
+                <label class="bot-control">
+                    <span>{{ t("lobby.components.battle.botParticipant.faction") }}</span>
+                    <Select
+                        data-test="bot-faction"
+                        :modelValue="bot.faction"
+                        :options="factionOptions"
+                        optionLabel="name"
+                        optionValue="value"
+                        @update:model-value="setBotFaction"
+                    />
+                </label>
+                <label v-if="difficultyOption" class="bot-control">
+                    <span>{{ difficultyOption.name }}</span>
+                    <Select
+                        data-test="bot-difficulty"
+                        :modelValue="bot.aiOptions[difficultyOption.key] ?? difficultyOption.default"
+                        :options="difficultyOption.options"
+                        optionLabel="name"
+                        optionValue="key"
+                        @update:model-value="setDifficulty"
+                    />
+                </label>
+            </div>
         </TeamParticipant>
         <LuaOptionsModal
             :id="`configure-bot-${bot.name}`"

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -25,7 +25,6 @@ SPDX-License-Identifier: MIT
                     />
                 </label>
                 <label v-if="difficultyOption" class="bot-control">
-                    <span>{{ difficultyOption.name }}</span>
                     <Select
                         data-test="bot-difficulty"
                         :modelValue="bot.aiOptions[difficultyOption.key] ?? difficultyOption.default"
@@ -83,11 +82,25 @@ const factionOptions = [
     { name: Faction.Cortex, value: Faction.Cortex },
 ];
 
+const barbProfileOptions: LuaOptionList["options"] = [
+    { key: "hard_aggressive", name: "Hard | Aggressive", type: "list" },
+    { key: "hard", name: "Hard | Balanced", type: "list" },
+    { key: "medium", name: "Medium | Lazy", type: "list" },
+    { key: "easy", name: "Easy | Slow", type: "list" },
+    { key: "dev", name: "Testing AI", type: "list" },
+];
+
 const hasInlineControls = computed(() => !isRaptor(props.bot) && !isScavenger(props.bot));
 const difficultyOption = computed(() => {
-    return getBotOptions()
+    const option = getBotOptions()
         .flatMap((section) => section.options)
-        .find((option): option is LuaOptionList => option.key === "difficulty" && option.type === "list" && !option.hidden);
+        .find((option): option is LuaOptionList => option.key === "profile" && option.type === "list" && !option.hidden);
+
+    if (option && props.bot.aiShortName === "BARb") {
+        return { ...option, options: barbProfileOptions };
+    }
+
+    return option;
 });
 
 const actions = [
@@ -148,7 +161,7 @@ function setDifficulty(difficulty: string) {
 function getBotOptions() {
     return (
         [...(enginesStore.selectedEngineVersion?.ais || []), ...(gameStore.selectedGameVersion?.ais || [])].find(
-            (ai) => ai.name === props.bot.name
+            (ai) => ai.shortName === props.bot.aiShortName
         )?.options || []
     );
 }
@@ -160,22 +173,29 @@ function getBotOptions() {
 }
 
 .bot-name {
-    flex: 1;
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .bot-controls {
     display: grid;
-    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    flex: 1;
+    min-width: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 8px;
-    margin-left: auto;
+    margin-left: 8px;
 }
 
 .bot-control {
-    display: grid;
-    grid-template-columns: auto minmax(100px, 1fr);
-    align-items: center;
-    gap: 5px;
+    min-width: 0;
     font-size: 12px;
+}
+
+.bot-control :deep(.select) {
+    width: 100%;
 }
 
 .bot-type {

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MIT
             <div class="bot-name">{{ bot.name }}</div>
             <div v-if="hasInlineControls" class="bot-controls">
                 <label class="bot-control">
-                    <span>{{ t("lobby.components.battle.botParticipant.faction") }}</span>
                     <Select
                         data-test="bot-faction"
                         :modelValue="bot.faction"
@@ -82,7 +81,6 @@ const menu = ref<InstanceType<typeof ContextMenu>>();
 const factionOptions = [
     { name: Faction.Armada, value: Faction.Armada },
     { name: Faction.Cortex, value: Faction.Cortex },
-    { name: Faction.Legion, value: Faction.Legion },
 ];
 
 const hasInlineControls = computed(() => !isRaptor(props.bot) && !isScavenger(props.bot));

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -133,7 +133,7 @@ function setBotOptions(options: Record<string, unknown>) {
     }
 }
 
-function setBotFaction(faction: Faction | undefined) {
+function setBotFaction(faction: Faction) {
     battleActions.updateBotFaction(props.bot, faction);
 }
 

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -5,14 +5,39 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div @contextmenu="onRightClick">
+    <div class="bot-participant" @contextmenu="onRightClick">
         <TeamParticipant>
             <div class="flex-row flex-center">
                 <GameIconsVelociraptor v-if="isRaptor(bot)" />
                 <Icon v-else-if="isScavenger(bot)" :icon="robotAngry" />
                 <Icon v-else :icon="robot" />
             </div>
-            <div>{{ bot.name }}</div>
+            <div class="bot-name">{{ bot.name }}</div>
+            <div v-if="hasInlineControls" class="bot-controls">
+                <label class="bot-control">
+                    <span>{{ t("lobby.components.battle.botParticipant.faction") }}</span>
+                    <Select
+                        data-test="bot-faction"
+                        :modelValue="bot.faction"
+                        :options="factionOptions"
+                        optionLabel="name"
+                        optionValue="value"
+                        :placeholder="t('lobby.components.battle.botParticipant.defaultFaction')"
+                        @update:model-value="setBotFaction"
+                    />
+                </label>
+                <label v-if="difficultyOption" class="bot-control">
+                    <span>{{ difficultyOption.name }}</span>
+                    <Select
+                        data-test="bot-difficulty"
+                        :modelValue="bot.aiOptions[difficultyOption.key] ?? difficultyOption.default"
+                        :options="difficultyOption.options"
+                        optionLabel="name"
+                        optionValue="key"
+                        @update:model-value="setDifficulty"
+                    />
+                </label>
+            </div>
         </TeamParticipant>
         <LuaOptionsModal
             :id="`configure-bot-${bot.name}`"
@@ -30,18 +55,19 @@ SPDX-License-Identifier: MIT
 import { Icon } from "@iconify/vue";
 import robot from "@iconify-icons/mdi/robot";
 import robotAngry from "@iconify-icons/mdi/robot-angry";
-import { Ref, ref } from "vue";
+import { computed, Ref, ref } from "vue";
 import { useTypedI18n } from "@renderer/i18n";
 
 import LuaOptionsModal from "@renderer/components/battle/LuaOptionsModal.vue";
 import TeamParticipant from "@renderer/components/battle/TeamParticipant.vue";
-import { LuaOptionSection } from "@main/content/game/lua-options";
-import { Bot, isRaptor, isScavenger } from "@main/game/battle/battle-types";
+import { LuaOptionList, LuaOptionSection } from "@main/content/game/lua-options";
+import { Bot, Faction, isRaptor, isScavenger } from "@main/game/battle/battle-types";
 import ContextMenu from "primevue/contextmenu";
 import { battleActions } from "@renderer/store/battle.store";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import GameIconsVelociraptor from "@renderer/components/icons/GameIconsVelociraptor.vue";
+import Select from "@renderer/components/controls/Select.vue";
 
 const { t } = useTypedI18n();
 
@@ -53,6 +79,19 @@ const props = defineProps<{
 const botOptions: Ref<LuaOptionSection[]> = ref([]);
 const botOptionsOpen = ref(false);
 const menu = ref<InstanceType<typeof ContextMenu>>();
+
+const factionOptions = [
+    { name: Faction.Armada, value: Faction.Armada },
+    { name: Faction.Cortex, value: Faction.Cortex },
+    { name: Faction.Legion, value: Faction.Legion },
+];
+
+const hasInlineControls = computed(() => !isRaptor(props.bot) && !isScavenger(props.bot));
+const difficultyOption = computed(() => {
+    return getBotOptions()
+        .flatMap((section) => section.options)
+        .find((option): option is LuaOptionList => option.key === "difficulty" && option.type === "list" && !option.hidden);
+});
 
 const actions = [
     {
@@ -85,19 +124,61 @@ function duplicateBot() {
 }
 
 async function configureBot() {
-    botOptions.value =
-        [...(enginesStore.selectedEngineVersion?.ais || []), ...(gameStore.selectedGameVersion?.ais || [])].find(
-            (ai) => ai.name === props.bot.name
-        )?.options || [];
+    botOptions.value = getBotOptions();
     botOptionsOpen.value = true;
 }
 
 function setBotOptions(options: Record<string, unknown>) {
     battleActions.updateBotOptions(props.bot, options);
 }
+
+function setBotFaction(faction: Faction | undefined) {
+    battleActions.updateBotFaction(props.bot, faction);
+}
+
+function setDifficulty(difficulty: string) {
+    if (!difficultyOption.value) return;
+
+    const options = { ...props.bot.aiOptions, [difficultyOption.value.key]: difficulty };
+    if (difficulty === difficultyOption.value.default) {
+        delete options[difficultyOption.value.key];
+    }
+    battleActions.updateBotOptions(props.bot, options);
+}
+
+function getBotOptions() {
+    return (
+        [...(enginesStore.selectedEngineVersion?.ais || []), ...(gameStore.selectedGameVersion?.ais || [])].find(
+            (ai) => ai.name === props.bot.name
+        )?.options || []
+    );
+}
 </script>
 
 <style lang="scss" scoped>
+.bot-participant {
+    height: 100%;
+}
+
+.bot-name {
+    flex: 1;
+}
+
+.bot-controls {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+    gap: 8px;
+    margin-left: auto;
+}
+
+.bot-control {
+    display: grid;
+    grid-template-columns: auto minmax(100px, 1fr);
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+}
+
 .bot-type {
     opacity: 0.5;
 }

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -93,7 +93,9 @@ async function configureBot() {
 }
 
 function setBotOptions(options: Record<string, unknown>) {
-    battleActions.updateBotOptions(props.bot, options);
+    if (!battleActions.updateBotOptions(props.bot, options)) {
+        botOptionsOpen.value = false;
+    }
 }
 </script>
 

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -127,9 +127,7 @@ async function configureBot() {
 }
 
 function setBotOptions(options: Record<string, unknown>) {
-    if (!battleActions.updateBotOptions(props.bot, options)) {
-        botOptionsOpen.value = false;
-    }
+    battleActions.updateBotOptions(props.bot, options);
 }
 
 function setBotFaction(faction: Faction) {

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -22,7 +22,6 @@ SPDX-License-Identifier: MIT
                         :options="factionOptions"
                         optionLabel="name"
                         optionValue="value"
-                        :placeholder="t('lobby.components.battle.botParticipant.defaultFaction')"
                         @update:model-value="setBotFaction"
                     />
                 </label>

--- a/src/renderer/components/battle/BotParticipant.vue
+++ b/src/renderer/components/battle/BotParticipant.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: MIT
                     <Select
                         data-test="bot-faction"
                         :modelValue="bot.faction"
-                        :options="factionOptions"
+                        :options="botFactionOptions"
                         optionLabel="name"
                         optionValue="value"
                         @update:model-value="setBotFaction"
@@ -58,6 +58,7 @@ import { useTypedI18n } from "@renderer/i18n";
 import LuaOptionsModal from "@renderer/components/battle/LuaOptionsModal.vue";
 import TeamParticipant from "@renderer/components/battle/TeamParticipant.vue";
 import { LuaOptionList, LuaOptionSection } from "@main/content/game/lua-options";
+import { barbProfileOptions, botFactionOptions } from "@main/game/battle/bot-options";
 import { Bot, Faction, isRaptor, isScavenger } from "@main/game/battle/battle-types";
 import ContextMenu from "primevue/contextmenu";
 import { battleActions } from "@renderer/store/battle.store";
@@ -76,19 +77,6 @@ const props = defineProps<{
 const botOptions: Ref<LuaOptionSection[]> = ref([]);
 const botOptionsOpen = ref(false);
 const menu = ref<InstanceType<typeof ContextMenu>>();
-
-const factionOptions = [
-    { name: Faction.Armada, value: Faction.Armada },
-    { name: Faction.Cortex, value: Faction.Cortex },
-];
-
-const barbProfileOptions: LuaOptionList["options"] = [
-    { key: "hard_aggressive", name: "Hard | Aggressive", type: "list" },
-    { key: "hard", name: "Hard | Balanced", type: "list" },
-    { key: "medium", name: "Medium | Lazy", type: "list" },
-    { key: "easy", name: "Easy | Slow", type: "list" },
-    { key: "dev", name: "Testing AI", type: "list" },
-];
 
 const hasInlineControls = computed(() => !isRaptor(props.bot) && !isScavenger(props.bot));
 const difficultyOption = computed(() => {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID, Faction } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -178,28 +178,15 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
-function findBot(bot: Bot) {
-    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
-}
-
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = findBot(bot);
+    const foundBot = battleStore.teams
+        .flat()
+        .filter((p) => isBot(p))
+        .find((p) => p.id === bot.id);
     if (!foundBot) {
-        return false;
+        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
     }
-
-    foundBot.aiOptions = options;
-    return true;
-}
-
-function updateBotFaction(bot: Bot, faction: Faction) {
-    const foundBot = findBot(bot);
-    if (!foundBot) {
-        return false;
-    }
-
-    foundBot.faction = faction;
-    return true;
+    bot.aiOptions = options;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {
@@ -629,7 +616,6 @@ export const battleActions = {
     addBot,
     removeBot,
     duplicateBot,
-    updateBotFaction,
     updateBotOptions,
     startBattle,
     updateTeams,

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID, Faction } from "@main/game/battle/battle-types";
+import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -178,15 +178,28 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
+function findBot(bot: Bot) {
+    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
+}
+
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = battleStore.teams
-        .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
+    const foundBot = findBot(bot);
     if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+        return false;
     }
-    bot.aiOptions = options;
+
+    foundBot.aiOptions = options;
+    return true;
+}
+
+function updateBotFaction(bot: Bot, faction: Faction) {
+    const foundBot = findBot(bot);
+    if (!foundBot) {
+        return false;
+    }
+
+    foundBot.faction = faction;
+    return true;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {
@@ -616,6 +629,7 @@ export const battleActions = {
     addBot,
     removeBot,
     duplicateBot,
+    updateBotFaction,
     updateBotOptions,
     startBattle,
     updateTeams,

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -183,9 +183,11 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
         .filter((p) => isBot(p))
         .find((p) => p.id === bot.id);
     if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+        return false;
     }
-    bot.aiOptions = options;
+
+    foundBot.aiOptions = options;
+    return true;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -178,28 +178,15 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
-function findBot(bot: Bot) {
-    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
-}
-
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = findBot(bot);
+    const foundBot = battleStore.teams
+        .flat()
+        .filter((p) => isBot(p))
+        .find((p) => p.id === bot.id);
     if (!foundBot) {
-        return false;
+        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
     }
-
-    foundBot.aiOptions = options;
-    return true;
-}
-
-function updateBotFaction(bot: Bot, faction: Faction) {
-    const foundBot = findBot(bot);
-    if (!foundBot) {
-        return false;
-    }
-
-    foundBot.faction = faction;
-    return true;
+    bot.aiOptions = options;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {
@@ -629,7 +616,6 @@ export const battleActions = {
     addBot,
     removeBot,
     duplicateBot,
-    updateBotFaction,
     updateBotOptions,
     startBattle,
     updateTeams,

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -183,9 +183,11 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
         .filter((p) => isBot(p))
         .find((p) => p.id === bot.id);
     if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+        return false;
     }
-    bot.aiOptions = options;
+
+    foundBot.aiOptions = options;
+    return true;
 }
 
 function updateBotFaction(bot: Bot, faction: Faction | undefined) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -177,16 +177,30 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
-function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = battleStore.teams
+function findBot(bot: Bot) {
+    return battleStore.teams
         .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
+        .filter((participant) => isBot(participant))
+        .find((participant) => participant.id === bot.id);
+}
+
+function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
+    const foundBot = findBot(bot);
     if (!foundBot) {
         return false;
     }
 
     foundBot.aiOptions = options;
+    return true;
+}
+
+function updateBotFaction(bot: Bot, faction: Faction | undefined) {
+    const foundBot = findBot(bot);
+    if (!foundBot) {
+        return false;
+    }
+
+    foundBot.faction = faction;
     return true;
 }
 

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -189,6 +189,17 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
     bot.aiOptions = options;
 }
 
+function updateBotFaction(bot: Bot, faction: Faction) {
+    const foundBot = battleStore.teams
+        .flat()
+        .filter((p) => isBot(p))
+        .find((p) => p.id === bot.id);
+    if (!foundBot) {
+        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+    }
+    foundBot.faction = faction;
+}
+
 function movePlayerToTeam(player: Player, teamId: number) {
     removeFromTeams(player);
     removeFromSpectators(player);
@@ -616,6 +627,7 @@ export const battleActions = {
     addBot,
     removeBot,
     duplicateBot,
+    updateBotFaction,
     updateBotOptions,
     startBattle,
     updateTeams,

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -161,6 +161,7 @@ function addBot(ai: EngineAI | GameAI, teamId: number) {
         name: ai.name,
         aiOptions: {},
         aiShortName: ai.shortName,
+        faction: Faction.Armada,
         host: battleStore.me.id,
     } satisfies Bot);
 }
@@ -178,10 +179,7 @@ function duplicateBot(bot: Bot, teamId: number) {
 }
 
 function findBot(bot: Bot) {
-    return battleStore.teams
-        .flat()
-        .filter((participant) => isBot(participant))
-        .find((participant) => participant.id === bot.id);
+    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
 }
 
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
@@ -194,7 +192,7 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
     return true;
 }
 
-function updateBotFaction(bot: Bot, faction: Faction | undefined) {
+function updateBotFaction(bot: Bot, faction: Faction) {
     const foundBot = findBot(bot);
     if (!foundBot) {
         return false;

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -178,26 +178,24 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
+function findBot(bot: Bot) {
+    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
+}
+
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = battleStore.teams
-        .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
-    if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
-    }
-    bot.aiOptions = options;
+    const foundBot = findBot(bot);
+    if (!foundBot) return false;
+
+    foundBot.aiOptions = options;
+    return true;
 }
 
 function updateBotFaction(bot: Bot, faction: Faction) {
-    const foundBot = battleStore.teams
-        .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
-    if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
-    }
+    const foundBot = findBot(bot);
+    if (!foundBot) return false;
+
     foundBot.faction = faction;
+    return true;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Battle, BattleWithMetadata, Bot, Faction, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Faction, Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -177,11 +177,15 @@ function duplicateBot(bot: Bot, teamId: number) {
     battleStore.teams[teamId].participants.push(newBot);
 }
 
-function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
-    const foundBot = battleStore.teams
+function findBot(bot: Bot) {
+    return battleStore.teams
         .flat()
-        .filter((p) => isBot(p))
-        .find((p) => p.id === bot.id);
+        .filter((participant) => isBot(participant))
+        .find((participant) => participant.id === bot.id);
+}
+
+function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
+    const foundBot = findBot(bot);
     if (!foundBot) {
         return false;
     }
@@ -191,14 +195,13 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
 }
 
 function updateBotFaction(bot: Bot, faction: Faction | undefined) {
-    const foundBot = battleStore.teams
-        .flat()
-        .filter((participant) => isBot(participant))
-        .find((participant) => participant.id === bot.id);
+    const foundBot = findBot(bot);
     if (!foundBot) {
-        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+        return false;
     }
+
     foundBot.faction = faction;
+    return true;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -5,7 +5,7 @@
 import { EngineAI, EngineVersion } from "@main/content/engine/engine-version";
 import { GameAI, GameVersion } from "@main/content/game/game-version";
 import { MapData } from "@main/content/maps/map-data";
-import { Battle, BattleWithMetadata, Bot, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
+import { Battle, BattleWithMetadata, Bot, Faction, isBot, isPlayer, isRaptor, isScavenger, isScavengerOrRaptor, Player, StartPosType, Team, GameModeID } from "@main/game/battle/battle-types";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 import { getRandomMap } from "@renderer/store/maps.store";
@@ -186,6 +186,17 @@ function updateBotOptions(bot: Bot, options: Record<string, unknown>) {
         throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
     }
     bot.aiOptions = options;
+}
+
+function updateBotFaction(bot: Bot, faction: Faction | undefined) {
+    const foundBot = battleStore.teams
+        .flat()
+        .filter((participant) => isBot(participant))
+        .find((participant) => participant.id === bot.id);
+    if (!foundBot) {
+        throw Error(`Failed to find bot ${bot.name} (${bot.id})`);
+    }
+    foundBot.faction = faction;
 }
 
 function movePlayerToTeam(player: Player, teamId: number) {
@@ -615,6 +626,7 @@ export const battleActions = {
     addBot,
     removeBot,
     duplicateBot,
+    updateBotFaction,
     updateBotOptions,
     startBattle,
     updateTeams,

--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -161,6 +161,7 @@ function addBot(ai: EngineAI | GameAI, teamId: number) {
         name: ai.name,
         aiOptions: {},
         aiShortName: ai.shortName,
+        faction: Faction.Armada,
         host: battleStore.me.id,
     } satisfies Bot);
 }
@@ -178,10 +179,7 @@ function duplicateBot(bot: Bot, teamId: number) {
 }
 
 function findBot(bot: Bot) {
-    return battleStore.teams
-        .flat()
-        .filter((participant) => isBot(participant))
-        .find((participant) => participant.id === bot.id);
+    return battleStore.teams.flatMap((team) => team.participants).find((participant): participant is Bot => isBot(participant) && participant.id === bot.id);
 }
 
 function updateBotOptions(bot: Bot, options: Record<string, unknown>) {

--- a/tests/unit/renderer/battle.store.spec.ts
+++ b/tests/unit/renderer/battle.store.spec.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reactive } from "vue";
+import { Faction, type Bot } from "@main/game/battle/battle-types";
+
+vi.mock("@renderer/store/engine.store", () => ({
+    enginesStore: reactive({ selectedEngineVersion: undefined }),
+}));
+
+vi.mock("@renderer/store/game.store", () => ({
+    gameStore: reactive({ selectedGameVersion: undefined }),
+    startBattle: vi.fn(),
+}));
+
+vi.mock("@renderer/store/maps.store", () => ({
+    getRandomMap: vi.fn(),
+}));
+
+vi.mock("@renderer/store/me.store", () => ({
+    me: reactive({
+        userId: "1",
+        username: "Player",
+        battleRoomState: {},
+    }),
+}));
+
+vi.mock("@renderer/api/notifications", () => ({
+    notificationsApi: { alert: vi.fn() },
+}));
+
+import { battleActions, battleStore } from "@renderer/store/battle.store";
+
+const bot: Bot = {
+    id: 1,
+    host: 2,
+    name: "BARbarIAn",
+    aiShortName: "BARb",
+    faction: Faction.Armada,
+    aiOptions: {},
+};
+
+describe("battle bot updates", () => {
+    beforeEach(() => {
+        battleStore.teams = [];
+    });
+
+    it("updates the current bot inside a team", () => {
+        const currentBot = { ...bot, aiOptions: {} };
+        battleStore.teams = [{ participants: [currentBot] }];
+
+        expect(battleActions.updateBotFaction(bot, Faction.Cortex)).toBe(true);
+        expect(battleActions.updateBotOptions(bot, { profile: "easy" })).toBe(true);
+        expect(currentBot.faction).toBe(Faction.Cortex);
+        expect(currentBot.aiOptions).toEqual({ profile: "easy" });
+    });
+
+    it("ignores an update emitted after the bot was removed", () => {
+        expect(battleActions.updateBotFaction(bot, Faction.Cortex)).toBe(false);
+        expect(battleActions.updateBotOptions(bot, { profile: "easy" })).toBe(false);
+    });
+});

--- a/tests/unit/renderer/bot-participant.spec.ts
+++ b/tests/unit/renderer/bot-participant.spec.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { defineComponent } from "vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BotParticipant from "@renderer/components/battle/BotParticipant.vue";
+import { Faction, type Bot } from "@main/game/battle/battle-types";
+
+const { updateBotFaction, updateBotOptions } = vi.hoisted(() => ({
+    updateBotFaction: vi.fn(),
+    updateBotOptions: vi.fn(),
+}));
+
+vi.mock("@renderer/store/battle.store", () => ({
+    battleActions: {
+        duplicateBot: vi.fn(),
+        removeBot: vi.fn(),
+        updateBotFaction,
+        updateBotOptions,
+    },
+}));
+
+vi.mock("@renderer/store/engine.store", () => ({
+    enginesStore: {
+        selectedEngineVersion: {
+            ais: [],
+        },
+    },
+}));
+
+vi.mock("@renderer/store/game.store", () => ({
+    gameStore: {
+        selectedGameVersion: {
+            ais: [
+                {
+                    name: "BARb",
+                    options: [
+                        {
+                            key: "general",
+                            name: "General",
+                            type: "section",
+                            options: [
+                                {
+                                    key: "difficulty",
+                                    name: "Difficulty",
+                                    type: "list",
+                                    default: "beginner",
+                                    options: [
+                                        { key: "beginner", name: "Beginner", type: "string" },
+                                        { key: "normal", name: "Normal", type: "string" },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+}));
+
+const SelectStub = defineComponent({
+    name: "BotSelect",
+    props: {
+        modelValue: { type: String, required: false },
+        options: { type: Array, required: true },
+    },
+    emits: ["update:modelValue"],
+    template: `
+        <button :data-test="$attrs['data-test']">
+            {{ options.find((option) => option.key === modelValue || option.value === modelValue)?.name ?? modelValue }}
+        </button>
+    `,
+});
+
+const TeamParticipantStub = defineComponent({
+    name: "TeamParticipant",
+    template: "<div><slot /></div>",
+});
+
+const bot: Bot = {
+    id: 1,
+    host: 2,
+    name: "BARb",
+    aiShortName: "BARb",
+    faction: Faction.Armada,
+    aiOptions: {},
+};
+
+function mountBotParticipant(options: Record<string, unknown> = {}) {
+    return mount(BotParticipant, {
+        props: {
+            bot: { ...bot, aiOptions: options },
+            teamId: 0,
+        },
+        global: {
+            stubs: {
+                ContextMenu: true,
+                Icon: true,
+                LuaOptionsModal: true,
+                Select: SelectStub,
+                TeamParticipant: TeamParticipantStub,
+            },
+        },
+    });
+}
+
+describe("BotParticipant", () => {
+    beforeEach(() => {
+        updateBotFaction.mockReset();
+        updateBotOptions.mockReset();
+    });
+
+    it("shows direct faction and effective default difficulty controls for a bot", () => {
+        const wrapper = mountBotParticipant();
+
+        expect(wrapper.find('[data-test="bot-faction"]').text()).toBe(Faction.Armada);
+        expect(wrapper.find('[data-test="bot-difficulty"]').text()).toBe("Beginner");
+    });
+
+    it("updates the bot faction and difficulty directly from the row", async () => {
+        const wrapper = mountBotParticipant({ difficulty: "beginner" });
+        const [factionControl, difficultyControl] = wrapper.findAllComponents(SelectStub);
+
+        await factionControl.vm.$emit("update:modelValue", Faction.Cortex);
+        await difficultyControl.vm.$emit("update:modelValue", "normal");
+
+        expect(updateBotFaction).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), Faction.Cortex);
+        expect(updateBotOptions).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), { difficulty: "normal" });
+    });
+});

--- a/tests/unit/renderer/bot-participant.spec.ts
+++ b/tests/unit/renderer/bot-participant.spec.ts
@@ -25,7 +25,28 @@ vi.mock("@renderer/store/battle.store", () => ({
 vi.mock("@renderer/store/engine.store", () => ({
     enginesStore: {
         selectedEngineVersion: {
-            ais: [],
+            ais: [
+                {
+                    name: "BARbarIAn",
+                    shortName: "BARb",
+                    options: [
+                        {
+                            key: "performance",
+                            name: "Performance Relevant Settings",
+                            type: "section",
+                            options: [
+                                {
+                                    key: "profile",
+                                    name: "Difficulty profile",
+                                    type: "list",
+                                    default: "hard",
+                                    options: [{ key: "dev", name: "Testing AI", type: "string" }],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
         },
     },
 }));
@@ -33,30 +54,7 @@ vi.mock("@renderer/store/engine.store", () => ({
 vi.mock("@renderer/store/game.store", () => ({
     gameStore: {
         selectedGameVersion: {
-            ais: [
-                {
-                    name: "BARb",
-                    options: [
-                        {
-                            key: "general",
-                            name: "General",
-                            type: "section",
-                            options: [
-                                {
-                                    key: "difficulty",
-                                    name: "Difficulty",
-                                    type: "list",
-                                    default: "beginner",
-                                    options: [
-                                        { key: "beginner", name: "Beginner", type: "string" },
-                                        { key: "normal", name: "Normal", type: "string" },
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
+            ais: [],
         },
     },
 }));
@@ -113,21 +111,21 @@ describe("BotParticipant", () => {
         updateBotOptions.mockReset();
     });
 
-    it("shows direct faction and effective default difficulty controls for a bot", () => {
+    it("shows direct faction and BARb's effective default difficulty profile", () => {
         const wrapper = mountBotParticipant();
 
         expect(wrapper.find('[data-test="bot-faction"]').text()).toBe(Faction.Armada);
-        expect(wrapper.find('[data-test="bot-difficulty"]').text()).toBe("Beginner");
+        expect(wrapper.find('[data-test="bot-difficulty"]').text()).toBe("Hard | Balanced");
     });
 
-    it("updates the bot faction and difficulty directly from the row", async () => {
-        const wrapper = mountBotParticipant({ difficulty: "beginner" });
+    it("updates the bot faction and difficulty profile directly from the row", async () => {
+        const wrapper = mountBotParticipant({ profile: "hard" });
         const [factionControl, difficultyControl] = wrapper.findAllComponents(SelectStub);
 
         await factionControl.vm.$emit("update:modelValue", Faction.Cortex);
-        await difficultyControl.vm.$emit("update:modelValue", "normal");
+        await difficultyControl.vm.$emit("update:modelValue", "easy");
 
         expect(updateBotFaction).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), Faction.Cortex);
-        expect(updateBotOptions).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), { difficulty: "normal" });
+        expect(updateBotOptions).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), { profile: "easy" });
     });
 });


### PR DESCRIPTION
Surfaces faction and BARb difficulty-profile selectors directly on ordinary bot participant rows, including the effective default profile.

Closes #639

## Acceptance criteria

- [x] Participants are presented as table rows.
- [x] Every ordinary bot row shows the bot’s faction.
- [x] Bot faction can be changed directly from the row.
- [x] BARb bot rows show their effective difficulty profile, including the default **Hard | Balanced** when no explicit profile is set.
- [x] BARb bot difficulty can be changed directly from the row.
- [x] Player rows do not expose faction or difficulty controls.
- [x] Changing bot faction or difficulty requires no intermediate menu or tab.