### PR TITLE
Fix game-mode selection lifecycle and lobby opening

### DIFF
--- a/src/renderer/components/battle/FullscreenGameModeSelector.vue
+++ b/src/renderer/components/battle/FullscreenGameModeSelector.vue
@@ -5,14 +5,9 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div class="fullscreen" :class="{ hidden: !battleStore.isSelectingGameMode }" @click="battleStore.isSelectingGameMode = false">
+    <div class="fullscreen" :class="{ hidden: !battleStore.isSelectingGameMode }" @click.self="closeOverlay">
         <div class="gamemode-container">
-            <GameModeSelector
-                @selected="
-                    battleStore.isSelectingGameMode = false;
-                    $emit('closed');
-                "
-            />
+            <GameModeSelector @selected="completeSelection" />
         </div>
     </div>
 </template>
@@ -20,21 +15,20 @@ SPDX-License-Identifier: MIT
 <script lang="ts" setup>
 import GameModeSelector from "@renderer/components/misc/GameModeSelector.vue";
 import { battleStore } from "@renderer/store/battle.store";
-import { ref, watch } from "vue";
 
-const props = defineProps<{
-    visible: boolean;
+const emit = defineEmits<{
+    closed: [];
 }>();
 
-defineEmits(["closed"]);
+function closeOverlay() {
+    battleStore.isSelectingGameMode = false;
+}
 
-const visible = ref(props.visible);
-watch(
-    () => props.visible,
-    (value) => {
-        visible.value = value;
-    }
-);
+function completeSelection() {
+    battleStore.isSelectingGameMode = false;
+    battleStore.isLobbyOpened = true;
+    emit("closed");
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/components/misc/GameModeSelector.vue
+++ b/src/renderer/components/misc/GameModeSelector.vue
@@ -6,43 +6,19 @@ SPDX-License-Identifier: MIT
 
 <template>
     <div class="mode-select">
-        <div
-            class="mode-column classic"
-            @click="
-                battleActions.loadGameMode(GameModeID.CLASSIC);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column classic" @click="selectGameMode(GameModeID.CLASSIC)">
             <span>{{ t("lobby.components.misc.gameModeSelector.classic") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.classicDescription") }}</button>
         </div>
-        <div
-            class="mode-column raptors"
-            @click="
-                battleActions.loadGameMode(GameModeID.RAPTORS);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column raptors" @click="selectGameMode(GameModeID.RAPTORS)">
             <span>{{ t("lobby.components.misc.gameModeSelector.raptors") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.raptorsDescription") }}</button>
         </div>
-        <div
-            class="mode-column scavengers"
-            @click="
-                battleActions.loadGameMode(GameModeID.SCAVENGERS);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column scavengers" @click="selectGameMode(GameModeID.SCAVENGERS)">
             <span>{{ t("lobby.components.misc.gameModeSelector.scavengers") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.scavengersDescription") }}</button>
         </div>
-        <div
-            class="mode-column ffa"
-            @click="
-                battleActions.loadGameMode(GameModeID.FFA);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column ffa" @click="selectGameMode(GameModeID.FFA)">
             <span>{{ t("lobby.components.misc.gameModeSelector.ffa") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.ffaDescription") }}</button>
         </div>
@@ -54,8 +30,14 @@ import { battleActions } from "@renderer/store/battle.store";
 import { useTypedI18n } from "@renderer/i18n";
 
 const { t } = useTypedI18n();
+const emit = defineEmits<{
+    selected: [];
+}>();
 
-defineEmits(["selected"]);
+async function selectGameMode(gameMode: GameModeID) {
+    await battleActions.loadGameMode(gameMode);
+    emit("selected");
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/views/library/maps/[id].vue
+++ b/src/renderer/views/library/maps/[id].vue
@@ -121,7 +121,6 @@ import gridIcon from "@iconify-icons/mdi/grid";
 import windPower from "@iconify-icons/mdi/wind-power";
 import { useTypedI18n } from "@renderer/i18n";
 import DownloadContentButton from "@renderer/components/controls/DownloadContentButton.vue";
-import { watch } from "vue";
 
 const { t } = useTypedI18n();
 
@@ -145,13 +144,6 @@ function toggleMapFavorite() {
 function routerBack() {
     router.back();
 }
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/views/news/overview.vue
+++ b/src/renderer/views/news/overview.vue
@@ -45,16 +45,8 @@ import DevlogFeed from "@renderer/components/misc/DevlogFeed.vue";
 import NewsFeed from "@renderer/components/misc/NewsFeed.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { battleStore } from "@renderer/store/battle.store";
-import { watch } from "vue";
 
 const { t } = useTypedI18n();
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/views/play/menu.vue
+++ b/src/renderer/views/play/menu.vue
@@ -67,7 +67,6 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script lang="ts" setup>
-import { watch } from "vue";
 import { useRouter } from "vue-router";
 import Panel from "@renderer/components/common/Panel.vue";
 import { settingsStore } from "@renderer/store/settings.store";
@@ -76,13 +75,6 @@ import { useTypedI18n } from "@renderer/i18n";
 const { t } = useTypedI18n();
 
 const router = useRouter();
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 
 // Game mode handlers
 const startSkirmish = () => {

--- a/tests/unit/renderer/fullscreen-game-mode-selector.spec.ts
+++ b/tests/unit/renderer/fullscreen-game-mode-selector.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import FullscreenGameModeSelector from "@renderer/components/battle/FullscreenGameModeSelector.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const battleStore = vi.hoisted(() => ({
+    isLobbyOpened: false,
+    isSelectingGameMode: true,
+}));
+
+vi.mock("@renderer/store/battle.store", () => ({ battleStore }));
+
+vi.mock("@renderer/components/misc/GameModeSelector.vue", () => ({
+    default: {
+        name: "GameModeSelector",
+        emits: ["selected"],
+        template: '<button data-testid="select-mode" @click="$emit(\'selected\')">Select</button>',
+    },
+}));
+
+describe("FullscreenGameModeSelector", () => {
+    beforeEach(() => {
+        battleStore.isLobbyOpened = false;
+        battleStore.isSelectingGameMode = true;
+    });
+
+    it("opens the battle room after a successful mode selection", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.get('[data-testid="select-mode"]').trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(false);
+        expect(battleStore.isLobbyOpened).toBe(true);
+        expect(wrapper.emitted("closed")).toHaveLength(1);
+    });
+
+    it("dismisses the backdrop without opening the battle room", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(false);
+        expect(battleStore.isLobbyOpened).toBe(false);
+        expect(wrapper.emitted("closed")).toBeUndefined();
+    });
+
+    it("does not dismiss when selector content is clicked", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.get(".gamemode-container").trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(true);
+        expect(battleStore.isLobbyOpened).toBe(false);
+    });
+});

--- a/tests/unit/renderer/game-mode-selector.spec.ts
+++ b/tests/unit/renderer/game-mode-selector.spec.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { GameModeID } from "@main/game/battle/battle-types";
+import GameModeSelector from "@renderer/components/misc/GameModeSelector.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadGameMode = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/store/battle.store", () => ({
+    battleActions: { loadGameMode },
+}));
+
+vi.mock("@renderer/i18n", () => ({
+    useTypedI18n: () => ({ t: (key: string) => key }),
+}));
+
+describe("GameModeSelector", () => {
+    beforeEach(() => {
+        loadGameMode.mockReset();
+    });
+
+    it("waits for Classic initialization before reporting selection", async () => {
+        let resolveLoad: () => void;
+        loadGameMode.mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveLoad = resolve;
+                })
+        );
+        const wrapper = mount(GameModeSelector);
+
+        await wrapper.get(".classic").trigger("click");
+
+        expect(loadGameMode).toHaveBeenCalledWith(GameModeID.CLASSIC);
+        expect(wrapper.emitted("selected")).toBeUndefined();
+
+        resolveLoad!();
+        await flushPromises();
+
+        expect(wrapper.emitted("selected")).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
Make game-mode selection completion explicit and asynchronous. The lobby now opens only after the selected game mode has finished loading successfully, while dismissing the selector leaves the lobby closed.

## Why

The selector previously used **“the selector closed”** as an implicit signal that game-mode selection had succeeded. That created two problems:

1. **Selection completion was reported too early.**  
   `GameModeSelector` emitted `selected` immediately after starting `loadGameMode()`, even though the game mode might still be initializing or could fail to load.

2. **Dismissal was indistinguishable from success.**  
   interpreted `isSelectingGameMode === false` as “open the lobby.” Closing the selector via the backdrop opened the lobby even though the user had not selected a mode.

The lifecycle should distinguish between:

- **Selection succeeded:** the mode loaded, then the lobby opens.
- **Selector dismissed:** the selector closes, but the lobby remains closed.

## Impact

### User impact

- The battle room opens only after the selected mode is ready.
- Canceling or clicking outside the selector no longer unexpectedly opens an empty lobby.
- Clicking inside the selector no longer closes it accidentally.
- Users receive a more predictable transition from mode selection to lobby setup.
