### PR TITLE
Modernize diagonal game-mode choice cards

### DIFF
--- a/src/renderer/components/battle/DiagonalChoiceLevel.vue
+++ b/src/renderer/components/battle/DiagonalChoiceLevel.vue
@@ -5,20 +5,28 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div class="mode-select">
-        <div
+    <div class="choice-level" :style="{ '--choice-count': choices.length }">
+        <button
             v-for="choice in choices"
             :key="choice.id"
-            :class="['mode-column', choice.id, { disabled: choice.disabled }]"
+            class="choice-item"
+            :class="choice.id"
             :data-choice-id="choice.id"
-            :style="{ backgroundImage: `url(${choice.backgroundImage})` }"
-            @click="selectChoice(choice)"
+            :disabled="choice.disabled"
+            type="button"
+            @click="emit('selected', choice.id)"
         >
-            <span>{{ choice.label }}</span>
-            <button class="quick-play-button" type="button" :disabled="choice.disabled">
-                {{ choice.description }}
-            </button>
-        </div>
+            <span class="art" :style="{ backgroundImage: `url(${choice.artwork})` }" aria-hidden="true"></span>
+            <span class="content">
+                <span v-if="choice.eyebrow" class="eyebrow">{{ choice.eyebrow }}</span>
+                <span class="title">{{ choice.title }}</span>
+                <span v-if="choice.description" class="description">
+                    {{ choice.description }}
+                </span>
+                <span v-if="choice.summary" class="summary">{{ choice.summary }}</span>
+                <span v-if="choice.actionLabel" class="action">{{ choice.actionLabel }}</span>
+            </span>
+        </button>
     </div>
 </template>
 
@@ -32,89 +40,100 @@ defineProps<{
 const emit = defineEmits<{
     selected: [id: string];
 }>();
-
-function selectChoice(choice: DiagonalChoice) {
-    if (!choice.disabled) {
-        emit("selected", choice.id);
-    }
-}
 </script>
 
 <style lang="scss" scoped>
-.mode-select {
+.choice-level {
     display: flex;
     height: 100%;
-    overflow: visible;
+    overflow: hidden;
+    container-type: inline-size;
 }
 
-.mode-column {
+.choice-item {
+    position: relative;
+    isolation: isolate;
+    min-width: 0;
     flex: 1;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: space-between;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    justify-content: center;
+    overflow: hidden;
+    border: 0;
+    padding: 0;
     color: white;
-    font-size: 2rem;
+    background: #10171e;
+    cursor: pointer;
     text-align: center;
-    transition: all 0.3s ease;
-    filter: brightness(0.7);
+    filter: brightness(0.85);
     transform: skewX(-5deg);
-    padding-top: 30px;
+    transition:
+        flex 300ms ease,
+        filter 300ms ease,
+        transform 300ms ease;
 
-    span {
-        font-size: 2rem;
-        text-transform: uppercase;
-        font-weight: bold;
-        filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
+    &::after {
+        position: absolute;
+        z-index: -1;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(6, 10, 14, 0.18), rgba(6, 10, 14, 0.78));
+        content: "";
+    }
+
+    &:not(:disabled):hover,
+    &:not(:disabled):focus-visible {
+        z-index: 1;
+        flex: 1.15;
+        filter: brightness(1.15);
+        outline: none;
+        transform: scale(1.025) skewX(-5deg);
     }
 }
 
-.mode-column:last-child {
-    border-right: none;
-}
-
-.mode-column:hover:not(.disabled) {
-    flex: 1.5;
-    z-index: 1;
-    filter: brightness(1);
-    transform: scale(1.05) skewX(0deg);
-    box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.5);
-}
-
-.mode-column.disabled {
+.choice-item:disabled {
     cursor: not-allowed;
     filter: brightness(0.5);
 }
 
-.quick-play-button {
-    height: 120px;
-    width: 100%;
-    align-self: center;
+.art {
+    position: absolute;
+    z-index: -2;
+    inset: -2px -80px;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    transform: skewX(5deg) scale(1.03);
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+    width: min(460px, calc(100cqw / var(--choice-count) - 48px));
+    gap: 20px;
+    transform: skewX(5deg);
+}
+
+.eyebrow,
+.action {
     text-transform: uppercase;
-    font-family: Rajdhani;
-    font-weight: bold;
-    font-size: 2rem;
-    padding: 20px calc(50% - 122px);
-    color: #fff;
-    background: linear-gradient(90deg, #22c55e, #16a34a);
-    border: none;
-    border-radius: 2px;
-    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
-    text-align: center;
-    cursor: pointer;
-    position: relative;
-    overflow: hidden;
-    transition: all 0.3s ease;
+    font-weight: 700;
+    letter-spacing: 0.08em;
 }
 
-.quick-play-button:hover {
-    box-shadow: 0 12px 25px rgba(34, 197, 94, 0.6);
+.title {
+    font-size: 3rem;
+    font-weight: 700;
+    text-transform: uppercase;
 }
 
-.quick-play-button:hover::before {
-    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
+.description {
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.summary {
+    font-size: 1.2rem;
 }
 </style>

--- a/src/renderer/components/battle/DiagonalChoiceLevel.vue
+++ b/src/renderer/components/battle/DiagonalChoiceLevel.vue
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+
+SPDX-License-Identifier: MIT
+-->
+
+<template>
+    <div class="mode-select">
+        <div
+            v-for="choice in choices"
+            :key="choice.id"
+            :class="['mode-column', choice.id, { disabled: choice.disabled }]"
+            :data-choice-id="choice.id"
+            :style="{ backgroundImage: `url(${choice.backgroundImage})` }"
+            @click="selectChoice(choice)"
+        >
+            <span>{{ choice.label }}</span>
+            <button class="quick-play-button" type="button" :disabled="choice.disabled">
+                {{ choice.description }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import type { DiagonalChoice } from "@renderer/components/battle/diagonal-choice.types";
+
+defineProps<{
+    choices: DiagonalChoice[];
+}>();
+
+const emit = defineEmits<{
+    selected: [id: string];
+}>();
+
+function selectChoice(choice: DiagonalChoice) {
+    if (!choice.disabled) {
+        emit("selected", choice.id);
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.mode-select {
+    display: flex;
+    height: 100%;
+    overflow: visible;
+}
+
+.mode-column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    color: white;
+    font-size: 2rem;
+    text-align: center;
+    transition: all 0.3s ease;
+    filter: brightness(0.7);
+    transform: skewX(-5deg);
+    padding-top: 30px;
+
+    span {
+        font-size: 2rem;
+        text-transform: uppercase;
+        font-weight: bold;
+        filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
+    }
+}
+
+.mode-column:last-child {
+    border-right: none;
+}
+
+.mode-column:hover:not(.disabled) {
+    flex: 1.5;
+    z-index: 1;
+    filter: brightness(1);
+    transform: scale(1.05) skewX(0deg);
+    box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.5);
+}
+
+.mode-column.disabled {
+    cursor: not-allowed;
+    filter: brightness(0.5);
+}
+
+.quick-play-button {
+    height: 120px;
+    width: 100%;
+    align-self: center;
+    text-transform: uppercase;
+    font-family: Rajdhani;
+    font-weight: bold;
+    font-size: 2rem;
+    padding: 20px calc(50% - 122px);
+    color: #fff;
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+    border: none;
+    border-radius: 2px;
+    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
+    text-align: center;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.quick-play-button:hover {
+    box-shadow: 0 12px 25px rgba(34, 197, 94, 0.6);
+}
+
+.quick-play-button:hover::before {
+    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
+}
+</style>

--- a/src/renderer/components/battle/FullscreenGameModeSelector.vue
+++ b/src/renderer/components/battle/FullscreenGameModeSelector.vue
@@ -5,14 +5,9 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div class="fullscreen" :class="{ hidden: !battleStore.isSelectingGameMode }" @click="battleStore.isSelectingGameMode = false">
+    <div class="fullscreen" :class="{ hidden: !battleStore.isSelectingGameMode }" @click.self="closeOverlay">
         <div class="gamemode-container">
-            <GameModeSelector
-                @selected="
-                    battleStore.isSelectingGameMode = false;
-                    $emit('closed');
-                "
-            />
+            <GameModeSelector @selected="completeSelection" />
         </div>
     </div>
 </template>
@@ -20,21 +15,20 @@ SPDX-License-Identifier: MIT
 <script lang="ts" setup>
 import GameModeSelector from "@renderer/components/misc/GameModeSelector.vue";
 import { battleStore } from "@renderer/store/battle.store";
-import { ref, watch } from "vue";
 
-const props = defineProps<{
-    visible: boolean;
+const emit = defineEmits<{
+    closed: [];
 }>();
 
-defineEmits(["closed"]);
+function closeOverlay() {
+    battleStore.isSelectingGameMode = false;
+}
 
-const visible = ref(props.visible);
-watch(
-    () => props.visible,
-    (value) => {
-        visible.value = value;
-    }
-);
+function completeSelection() {
+    battleStore.isSelectingGameMode = false;
+    battleStore.isLobbyOpened = true;
+    emit("closed");
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/components/battle/diagonal-choice.types.ts
+++ b/src/renderer/components/battle/diagonal-choice.types.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+export interface DiagonalChoice {
+    id: string;
+    label: string;
+    description?: string;
+    backgroundImage: string;
+    disabled?: boolean;
+}

--- a/src/renderer/components/battle/diagonal-choice.types.ts
+++ b/src/renderer/components/battle/diagonal-choice.types.ts
@@ -4,8 +4,11 @@
 
 export interface DiagonalChoice {
     id: string;
-    label: string;
+    title: string;
+    artwork: string;
+    eyebrow?: string;
     description?: string;
-    backgroundImage: string;
+    summary?: string;
+    actionLabel?: string;
     disabled?: boolean;
 }

--- a/src/renderer/components/misc/GameModeSelector.vue
+++ b/src/renderer/components/misc/GameModeSelector.vue
@@ -5,123 +5,63 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div class="mode-select">
-        <div class="mode-column classic" @click="selectGameMode(GameModeID.CLASSIC)">
-            <span>{{ t("lobby.components.misc.gameModeSelector.classic") }}</span>
-            <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.classicDescription") }}</button>
-        </div>
-        <div class="mode-column raptors" @click="selectGameMode(GameModeID.RAPTORS)">
-            <span>{{ t("lobby.components.misc.gameModeSelector.raptors") }}</span>
-            <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.raptorsDescription") }}</button>
-        </div>
-        <div class="mode-column scavengers" @click="selectGameMode(GameModeID.SCAVENGERS)">
-            <span>{{ t("lobby.components.misc.gameModeSelector.scavengers") }}</span>
-            <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.scavengersDescription") }}</button>
-        </div>
-        <div class="mode-column ffa" @click="selectGameMode(GameModeID.FFA)">
-            <span>{{ t("lobby.components.misc.gameModeSelector.ffa") }}</span>
-            <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.ffaDescription") }}</button>
-        </div>
-    </div>
+    <DiagonalChoiceLevel :choices="choices" @selected="selectGameMode" />
 </template>
+
 <script lang="ts" setup>
 import { GameModeID } from "@main/game/battle/battle-types";
-import { battleActions } from "@renderer/store/battle.store";
+import DiagonalChoiceLevel from "@renderer/components/battle/DiagonalChoiceLevel.vue";
+import type { DiagonalChoice } from "@renderer/components/battle/diagonal-choice.types";
 import { useTypedI18n } from "@renderer/i18n";
+import { battleActions } from "@renderer/store/battle.store";
 
 const { t } = useTypedI18n();
 const emit = defineEmits<{
     selected: [];
 }>();
 
-async function selectGameMode(gameMode: GameModeID) {
+const choices: DiagonalChoice[] = [
+    {
+        id: "classic",
+        label: t("lobby.components.misc.gameModeSelector.classic"),
+        description: t("lobby.components.misc.gameModeSelector.classicDescription"),
+        backgroundImage: "/src/renderer/assets/images/backgrounds/5.jpg",
+    },
+    {
+        id: "raptors",
+        label: t("lobby.components.misc.gameModeSelector.raptors"),
+        description: t("lobby.components.misc.gameModeSelector.raptorsDescription"),
+        backgroundImage: "/src/renderer/assets/images/modes/raptors.jpg",
+    },
+    {
+        id: "scavengers",
+        label: t("lobby.components.misc.gameModeSelector.scavengers"),
+        description: t("lobby.components.misc.gameModeSelector.scavengersDescription"),
+        backgroundImage: "/src/renderer/assets/images/modes/scavengers.webp",
+    },
+    {
+        id: "ffa",
+        label: t("lobby.components.misc.gameModeSelector.ffa"),
+        description: t("lobby.components.misc.gameModeSelector.ffaDescription"),
+        backgroundImage: "/src/renderer/assets/images/modes/ffa.jpg",
+    },
+];
+
+const gameModeByChoiceId: Record<string, GameModeID> = {
+    classic: GameModeID.CLASSIC,
+    raptors: GameModeID.RAPTORS,
+    scavengers: GameModeID.SCAVENGERS,
+    ffa: GameModeID.FFA,
+};
+
+async function selectGameMode(choiceId: string) {
+    const gameMode = gameModeByChoiceId[choiceId];
+
+    if (gameMode === undefined) {
+        return;
+    }
+
     await battleActions.loadGameMode(gameMode);
     emit("selected");
 }
 </script>
-
-<style lang="scss" scoped>
-.mode-select {
-    display: flex;
-    height: 100%;
-    overflow: visible;
-}
-
-.mode-column {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    color: white;
-    font-size: 2rem;
-    text-align: center;
-    transition: all 0.3s ease;
-    filter: brightness(0.7);
-    transform: skewX(-5deg);
-    padding-top: 30px;
-    span {
-        font-size: 2rem;
-        text-transform: uppercase;
-        font-weight: bold;
-        filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
-    }
-    &.classic {
-        background-image: url("/src/renderer/assets/images/backgrounds/5.jpg");
-    }
-    &.raptors {
-        background-image: url("/src/renderer/assets/images/modes/raptors.jpg");
-    }
-    &.scavengers {
-        background-image: url("/src/renderer/assets/images/modes/scavengers.webp");
-    }
-    &.ffa {
-        background-image: url("/src/renderer/assets/images/modes/ffa.jpg");
-    }
-}
-
-.mode-column:last-child {
-    border-right: none;
-}
-
-/* On hover/active */
-.mode-column:hover {
-    flex: 1.5;
-    z-index: 1;
-    filter: brightness(1);
-    transform: scale(1.05) skewX(0deg);
-    box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.5);
-}
-
-.quick-play-button {
-    height: 120px;
-    width: 100%;
-    align-self: center;
-    text-transform: uppercase;
-    font-family: Rajdhani;
-    font-weight: bold;
-    font-size: 2rem;
-    padding: 20px calc(50% - 122px);
-    color: #fff;
-    background: linear-gradient(90deg, #22c55e, #16a34a);
-    border: none;
-    border-radius: 2px;
-    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
-    text-align: center;
-    cursor: pointer;
-    position: relative;
-    overflow: hidden;
-    transition: all 0.3s ease;
-}
-
-.quick-play-button:hover {
-    box-shadow: 0 12px 25px rgba(34, 197, 94, 0.6);
-}
-
-.quick-play-button:hover::before {
-    box-shadow: 0 8px 15px rgba(34, 197, 94, 0.4);
-}
-</style>

--- a/src/renderer/components/misc/GameModeSelector.vue
+++ b/src/renderer/components/misc/GameModeSelector.vue
@@ -6,43 +6,19 @@ SPDX-License-Identifier: MIT
 
 <template>
     <div class="mode-select">
-        <div
-            class="mode-column classic"
-            @click="
-                battleActions.loadGameMode(GameModeID.CLASSIC);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column classic" @click="selectGameMode(GameModeID.CLASSIC)">
             <span>{{ t("lobby.components.misc.gameModeSelector.classic") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.classicDescription") }}</button>
         </div>
-        <div
-            class="mode-column raptors"
-            @click="
-                battleActions.loadGameMode(GameModeID.RAPTORS);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column raptors" @click="selectGameMode(GameModeID.RAPTORS)">
             <span>{{ t("lobby.components.misc.gameModeSelector.raptors") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.raptorsDescription") }}</button>
         </div>
-        <div
-            class="mode-column scavengers"
-            @click="
-                battleActions.loadGameMode(GameModeID.SCAVENGERS);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column scavengers" @click="selectGameMode(GameModeID.SCAVENGERS)">
             <span>{{ t("lobby.components.misc.gameModeSelector.scavengers") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.scavengersDescription") }}</button>
         </div>
-        <div
-            class="mode-column ffa"
-            @click="
-                battleActions.loadGameMode(GameModeID.FFA);
-                $emit('selected');
-            "
-        >
+        <div class="mode-column ffa" @click="selectGameMode(GameModeID.FFA)">
             <span>{{ t("lobby.components.misc.gameModeSelector.ffa") }}</span>
             <button class="quick-play-button">{{ t("lobby.components.misc.gameModeSelector.ffaDescription") }}</button>
         </div>
@@ -54,8 +30,14 @@ import { battleActions } from "@renderer/store/battle.store";
 import { useTypedI18n } from "@renderer/i18n";
 
 const { t } = useTypedI18n();
+const emit = defineEmits<{
+    selected: [];
+}>();
 
-defineEmits(["selected"]);
+async function selectGameMode(gameMode: GameModeID) {
+    await battleActions.loadGameMode(gameMode);
+    emit("selected");
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/components/misc/GameModeSelector.vue
+++ b/src/renderer/components/misc/GameModeSelector.vue
@@ -23,27 +23,27 @@ const emit = defineEmits<{
 const choices: DiagonalChoice[] = [
     {
         id: "classic",
-        label: t("lobby.components.misc.gameModeSelector.classic"),
+        title: t("lobby.components.misc.gameModeSelector.classic"),
         description: t("lobby.components.misc.gameModeSelector.classicDescription"),
-        backgroundImage: "/src/renderer/assets/images/backgrounds/5.jpg",
+        artwork: "/src/renderer/assets/images/backgrounds/5.jpg",
     },
     {
         id: "raptors",
-        label: t("lobby.components.misc.gameModeSelector.raptors"),
+        title: t("lobby.components.misc.gameModeSelector.raptors"),
         description: t("lobby.components.misc.gameModeSelector.raptorsDescription"),
-        backgroundImage: "/src/renderer/assets/images/modes/raptors.jpg",
+        artwork: "/src/renderer/assets/images/modes/raptors.jpg",
     },
     {
         id: "scavengers",
-        label: t("lobby.components.misc.gameModeSelector.scavengers"),
+        title: t("lobby.components.misc.gameModeSelector.scavengers"),
         description: t("lobby.components.misc.gameModeSelector.scavengersDescription"),
-        backgroundImage: "/src/renderer/assets/images/modes/scavengers.webp",
+        artwork: "/src/renderer/assets/images/modes/scavengers.webp",
     },
     {
         id: "ffa",
-        label: t("lobby.components.misc.gameModeSelector.ffa"),
+        title: t("lobby.components.misc.gameModeSelector.ffa"),
         description: t("lobby.components.misc.gameModeSelector.ffaDescription"),
-        backgroundImage: "/src/renderer/assets/images/modes/ffa.jpg",
+        artwork: "/src/renderer/assets/images/modes/ffa.jpg",
     },
 ];
 

--- a/src/renderer/views/library/maps/[id].vue
+++ b/src/renderer/views/library/maps/[id].vue
@@ -121,7 +121,6 @@ import gridIcon from "@iconify-icons/mdi/grid";
 import windPower from "@iconify-icons/mdi/wind-power";
 import { useTypedI18n } from "@renderer/i18n";
 import DownloadContentButton from "@renderer/components/controls/DownloadContentButton.vue";
-import { watch } from "vue";
 
 const { t } = useTypedI18n();
 
@@ -145,13 +144,6 @@ function toggleMapFavorite() {
 function routerBack() {
     router.back();
 }
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/views/news/overview.vue
+++ b/src/renderer/views/news/overview.vue
@@ -45,16 +45,8 @@ import DevlogFeed from "@renderer/components/misc/DevlogFeed.vue";
 import NewsFeed from "@renderer/components/misc/NewsFeed.vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { battleStore } from "@renderer/store/battle.store";
-import { watch } from "vue";
 
 const { t } = useTypedI18n();
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/views/play/menu.vue
+++ b/src/renderer/views/play/menu.vue
@@ -67,7 +67,6 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script lang="ts" setup>
-import { watch } from "vue";
 import { useRouter } from "vue-router";
 import Panel from "@renderer/components/common/Panel.vue";
 import { settingsStore } from "@renderer/store/settings.store";
@@ -76,13 +75,6 @@ import { useTypedI18n } from "@renderer/i18n";
 const { t } = useTypedI18n();
 
 const router = useRouter();
-
-watch(
-    () => battleStore.isSelectingGameMode,
-    (newValue) => {
-        battleStore.isLobbyOpened = !newValue;
-    }
-);
 
 // Game mode handlers
 const startSkirmish = () => {

--- a/tests/unit/renderer/diagonal-choice-level.spec.ts
+++ b/tests/unit/renderer/diagonal-choice-level.spec.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import DiagonalChoiceLevel from "@renderer/components/battle/DiagonalChoiceLevel.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+const choices = [
+    {
+        id: "alpha",
+        label: "Alpha",
+        description: "First choice",
+        backgroundImage: "/alpha.jpg",
+    },
+    {
+        id: "beta",
+        label: "Beta",
+        description: "Second choice",
+        backgroundImage: "/beta.jpg",
+    },
+];
+
+describe("DiagonalChoiceLevel", () => {
+    it("renders each choice and its background image", () => {
+        const wrapper = mount(DiagonalChoiceLevel, { props: { choices } });
+
+        expect(wrapper.findAll("[data-choice-id]")).toHaveLength(2);
+        expect(wrapper.get('[data-choice-id="alpha"]').text()).toContain("First choice");
+        expect(wrapper.get('[data-choice-id="alpha"]').attributes("style")).toContain('background-image: url("/alpha.jpg")');
+    });
+
+    it("emits the selected choice id", async () => {
+        const wrapper = mount(DiagonalChoiceLevel, { props: { choices } });
+
+        await wrapper.get('[data-choice-id="beta"]').trigger("click");
+
+        expect(wrapper.emitted("selected")).toEqual([["beta"]]);
+    });
+
+    it("does not emit a disabled choice", async () => {
+        const wrapper = mount(DiagonalChoiceLevel, {
+            props: {
+                choices: [{ ...choices[0], disabled: true }],
+            },
+        });
+
+        await wrapper.get('[data-choice-id="alpha"]').trigger("click");
+
+        expect(wrapper.emitted("selected")).toBeUndefined();
+    });
+});

--- a/tests/unit/renderer/diagonal-choice-level.spec.ts
+++ b/tests/unit/renderer/diagonal-choice-level.spec.ts
@@ -9,25 +9,50 @@ import { describe, expect, it } from "vitest";
 const choices = [
     {
         id: "alpha",
-        label: "Alpha",
+        title: "Alpha",
+        eyebrow: "Recommended",
         description: "First choice",
-        backgroundImage: "/alpha.jpg",
+        summary: "Two teams",
+        actionLabel: "Configure",
+        artwork: "/alpha.jpg",
     },
     {
         id: "beta",
-        label: "Beta",
+        title: "Beta",
         description: "Second choice",
-        backgroundImage: "/beta.jpg",
+        artwork: "/beta.jpg",
     },
 ];
 
 describe("DiagonalChoiceLevel", () => {
-    it("renders each choice and its background image", () => {
+    it("renders each choice as a full-card button with decorative artwork", () => {
         const wrapper = mount(DiagonalChoiceLevel, { props: { choices } });
+        const alpha = wrapper.get('[data-choice-id="alpha"]');
 
         expect(wrapper.findAll("[data-choice-id]")).toHaveLength(2);
-        expect(wrapper.get('[data-choice-id="alpha"]').text()).toContain("First choice");
-        expect(wrapper.get('[data-choice-id="alpha"]').attributes("style")).toContain('background-image: url("/alpha.jpg")');
+        expect(alpha.element.tagName).toBe("BUTTON");
+        expect(alpha.attributes("type")).toBe("button");
+        expect(alpha.get(".art").attributes("aria-hidden")).toBe("true");
+        expect(alpha.get(".art").attributes("style")).toContain('background-image: url("/alpha.jpg")');
+        expect(alpha.attributes("style") ?? "").not.toContain("background-image");
+    });
+
+    it("renders the optional content hierarchy", () => {
+        const wrapper = mount(DiagonalChoiceLevel, { props: { choices } });
+        const alpha = wrapper.get('[data-choice-id="alpha"]');
+
+        expect(alpha.get(".eyebrow").text()).toBe("Recommended");
+        expect(alpha.get(".title").text()).toBe("Alpha");
+        expect(alpha.get(".description").text()).toBe("First choice");
+        expect(alpha.get(".summary").text()).toBe("Two teams");
+        expect(alpha.get(".action").text()).toBe("Configure");
+        expect(alpha.find(".quick-play-button").exists()).toBe(false);
+    });
+
+    it("exposes the number of choices for responsive sizing", () => {
+        const wrapper = mount(DiagonalChoiceLevel, { props: { choices } });
+
+        expect(wrapper.attributes("style")).toContain("--choice-count: 2");
     });
 
     it("emits the selected choice id", async () => {
@@ -44,8 +69,10 @@ describe("DiagonalChoiceLevel", () => {
                 choices: [{ ...choices[0], disabled: true }],
             },
         });
+        const choice = wrapper.get('[data-choice-id="alpha"]');
 
-        await wrapper.get('[data-choice-id="alpha"]').trigger("click");
+        expect(choice.attributes("disabled")).toBeDefined();
+        await choice.trigger("click");
 
         expect(wrapper.emitted("selected")).toBeUndefined();
     });

--- a/tests/unit/renderer/fullscreen-game-mode-selector.spec.ts
+++ b/tests/unit/renderer/fullscreen-game-mode-selector.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import FullscreenGameModeSelector from "@renderer/components/battle/FullscreenGameModeSelector.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const battleStore = vi.hoisted(() => ({
+    isLobbyOpened: false,
+    isSelectingGameMode: true,
+}));
+
+vi.mock("@renderer/store/battle.store", () => ({ battleStore }));
+
+vi.mock("@renderer/components/misc/GameModeSelector.vue", () => ({
+    default: {
+        name: "GameModeSelector",
+        emits: ["selected"],
+        template: '<button data-testid="select-mode" @click="$emit(\'selected\')">Select</button>',
+    },
+}));
+
+describe("FullscreenGameModeSelector", () => {
+    beforeEach(() => {
+        battleStore.isLobbyOpened = false;
+        battleStore.isSelectingGameMode = true;
+    });
+
+    it("opens the battle room after a successful mode selection", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.get('[data-testid="select-mode"]').trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(false);
+        expect(battleStore.isLobbyOpened).toBe(true);
+        expect(wrapper.emitted("closed")).toHaveLength(1);
+    });
+
+    it("dismisses the backdrop without opening the battle room", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(false);
+        expect(battleStore.isLobbyOpened).toBe(false);
+        expect(wrapper.emitted("closed")).toBeUndefined();
+    });
+
+    it("does not dismiss when selector content is clicked", async () => {
+        const wrapper = mount(FullscreenGameModeSelector, { props: { visible: true } });
+
+        await wrapper.get(".gamemode-container").trigger("click");
+
+        expect(battleStore.isSelectingGameMode).toBe(true);
+        expect(battleStore.isLobbyOpened).toBe(false);
+    });
+});

--- a/tests/unit/renderer/game-mode-selector.spec.ts
+++ b/tests/unit/renderer/game-mode-selector.spec.ts
@@ -22,6 +22,16 @@ describe("GameModeSelector", () => {
         loadGameMode.mockReset();
     });
 
+    it("renders all four game modes with their artwork", () => {
+        const wrapper = mount(GameModeSelector);
+
+        expect(wrapper.findAll("[data-choice-id]")).toHaveLength(4);
+        expect(wrapper.get('[data-choice-id="classic"] .art').attributes("style")).toContain("/src/renderer/assets/images/backgrounds/5.jpg");
+        expect(wrapper.get('[data-choice-id="raptors"] .art').attributes("style")).toContain("/src/renderer/assets/images/modes/raptors.jpg");
+        expect(wrapper.get('[data-choice-id="scavengers"] .art').attributes("style")).toContain("/src/renderer/assets/images/modes/scavengers.webp");
+        expect(wrapper.get('[data-choice-id="ffa"] .art').attributes("style")).toContain("/src/renderer/assets/images/modes/ffa.jpg");
+    });
+
     it("waits for Classic initialization before reporting selection", async () => {
         let resolveLoad: () => void;
         loadGameMode.mockImplementationOnce(

--- a/tests/unit/renderer/game-mode-selector.spec.ts
+++ b/tests/unit/renderer/game-mode-selector.spec.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { GameModeID } from "@main/game/battle/battle-types";
+import GameModeSelector from "@renderer/components/misc/GameModeSelector.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadGameMode = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/store/battle.store", () => ({
+    battleActions: { loadGameMode },
+}));
+
+vi.mock("@renderer/i18n", () => ({
+    useTypedI18n: () => ({ t: (key: string) => key }),
+}));
+
+describe("GameModeSelector", () => {
+    beforeEach(() => {
+        loadGameMode.mockReset();
+    });
+
+    it("waits for Classic initialization before reporting selection", async () => {
+        let resolveLoad: () => void;
+        loadGameMode.mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveLoad = resolve;
+                })
+        );
+        const wrapper = mount(GameModeSelector);
+
+        await wrapper.get(".classic").trigger("click");
+
+        expect(loadGameMode).toHaveBeenCalledWith(GameModeID.CLASSIC);
+        expect(wrapper.emitted("selected")).toBeUndefined();
+
+        resolveLoad!();
+        await flushPromises();
+
+        expect(wrapper.emitted("selected")).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary

Modernizes the existing four-option diagonal game-mode selector while preserving its current choices and battle-room behavior. The change adds full-card buttons, dedicated artwork layers, improved readability treatment, structured content hierarchy, responsive copy sizing, and restrained hover/focus behavior.

## Review order

Please review and merge [PR #645](https://github.com/beyond-all-reason/bar-lobby/pull/645) first: **Fix game-mode selection lifecycle and lobby opening**. This PR builds on that lifecycle work and should be reviewed afterward.

## Old UI

<img width="800" height="450" alt="old_diagonal" src="https://github.com/user-attachments/assets/7544a0a8-adac-4441-b5e2-dca0e2dc312a" />


## New UI


<img width="800" height="450" alt="new_diagonal" src="https://github.com/user-attachments/assets/2ec79337-8be7-4471-9d9c-1019fdcd0403" />
