### PR TITLE
Stop rejected second instances creating log files

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,16 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { app } from "electron";
+import "@main/single-instance";
 
-const gotTheLock = app.requestSingleInstanceLock();
-
-if (!gotTheLock) {
-    app.exit(0);
-}
-
-// Only import after we know we have the lock
-import { net, protocol, session } from "electron";
+import { app, net, protocol, session } from "electron";
 import path from "path";
 import url from "url";
 import netFromNode from "node:net";

--- a/src/main/single-instance.ts
+++ b/src/main/single-instance.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { app } from "electron";
+
+// Imports are hoisted, so the lock has to be taken by the first module in the
+// graph rather than at the top of main.ts, or modules that log while loading
+// will have already opened a log file.
+if (!app.requestSingleInstanceLock()) {
+    app.exit(0);
+}


### PR DESCRIPTION
Imports get hoisted, so the lock in main.ts was actually being taken after every other module had already loaded, including the logger, which opens a log file just from being imported. That means a rejected second instance still creates a log file before it exits. Might be where some of the extra files in the screenshot on #610 come from.

Moves the lock into its own module that gets imported first, so nothing else has run by the time it happens. I checked the built bundle before and after and the lock now lands ahead of the logger setting up. The old comment in main.ts saying imports were ordered is gone since it wasn't true.

I haven't reproduced the original report, the only thing mentioned being replays but I couldn't get that to trigger the described behavior.

#618 is also open against this issue and covers a lot more ground.

Developed with Claude Code.
