### PR TITLE
Tidy up leftover files in the logs directory

### DIFF
--- a/src/main/services/log.service.ts
+++ b/src/main/services/log.service.ts
@@ -10,7 +10,10 @@ import { packSpecificFiles } from "@main/utils/pack-7z";
 import { randomBytes } from "crypto";
 import axios from "axios";
 import { logger } from "@main/utils/logger";
+import { LOG_FILE_NAME } from "@main/utils/log-file-name";
 import { configService } from "@main/services/config.service";
+
+const PACK_COPY_GLOB = "*most_recent.log";
 
 async function getSortedLogFiles() {
     type logData = {
@@ -21,6 +24,7 @@ async function getSortedLogFiles() {
     // Get the log files from the log directory.
     const fileList: string[] = [];
     for await (const entry of glob("*.log", { cwd: LOGS_PATH })) {
+        if (!LOG_FILE_NAME.test(entry)) continue;
         const logPath = path.join(LOGS_PATH, entry);
         fileList.push(logPath);
     }
@@ -61,6 +65,11 @@ export async function purgeLogFiles() {
         await rm(zipPath);
     }
 
+    // Delete copies left behind by an interrupted pack.
+    for await (const entry of glob(PACK_COPY_GLOB, { cwd: LOGS_PATH })) {
+        await rm(path.join(LOGS_PATH, entry));
+    }
+
     return mostRecentFiles;
 }
 
@@ -91,10 +100,12 @@ export async function packLogFiles() {
     const archiveFile = `logs-${archiveTime}-${archiveRandom}.zip`;
     const archivePath = path.join(LOGS_PATH, archiveFile);
 
-    await packSpecificFiles(archivePath, filesToPack);
+    try {
+        await packSpecificFiles(archivePath, filesToPack);
+    } finally {
+        await rm(newFilePath, { force: true });
+    }
 
-    // Delete the copied file.
-    await rm(newFilePath);
     return archivePath;
 }
 
@@ -119,7 +130,7 @@ async function uploadLogFiles() {
     });
 
     // Delete the ZIP file after upload
-    rm(archivePath);
+    await rm(archivePath, { force: true });
 
     return uploadUrl;
 }

--- a/src/main/utils/log-file-name.ts
+++ b/src/main/utils/log-file-name.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+const PREFIX = "lobby-";
+const EXTENSION = "log";
+const RUN_ID_PATTERN = "\\d{8}T\\d{6}";
+
+export const LOG_FILE_NAME = new RegExp(`^${PREFIX}${RUN_ID_PATTERN}\\.${EXTENSION}$`);
+
+export function logFileName(date: Date) {
+    const runId = date
+        .toISOString()
+        .replace(/[^0-9T]/g, "")
+        .substring(0, 15);
+
+    return `${PREFIX}${runId}.${EXTENSION}`;
+}

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -5,6 +5,7 @@
 import pino from "pino";
 import PinoPretty from "pino-pretty";
 import { LOGS_PATH, LOG_LEVEL } from "@main/config/app";
+import { logFileName } from "@main/utils/log-file-name";
 import path from "path";
 import { mkdirSync } from "fs";
 
@@ -22,11 +23,7 @@ const stdStream = PinoPretty({
     destination: 1,
 });
 
-const runId = new Date()
-    .toISOString()
-    .replace(/[^0-9T]/g, "")
-    .substring(0, 15);
-const logFilePath = path.join(LOGS_PATH, `lobby-${runId}.log`);
+const logFilePath = path.join(LOGS_PATH, logFileName(new Date()));
 
 const logStream = PinoPretty({
     ...messageFormatting,

--- a/tests/unit/main/log-file-name.spec.ts
+++ b/tests/unit/main/log-file-name.spec.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+import { LOG_FILE_NAME, logFileName } from "@main/utils/log-file-name";
+
+const runStart = new Date("2026-07-27T13:18:00.000Z");
+
+describe("log file naming", () => {
+    it("names a run log after the time it started", () => {
+        expect(logFileName(runStart)).toBe("lobby-20260727T131800.log");
+    });
+
+    it("matches the names the logger creates", () => {
+        expect(logFileName(runStart)).toMatch(LOG_FILE_NAME);
+    });
+
+    it("does not match the copy taken when packing logs for upload", () => {
+        const copy = `${logFileName(runStart).replace(/\.log$/, "")}most_recent.log`;
+
+        expect(copy).not.toMatch(LOG_FILE_NAME);
+    });
+});


### PR DESCRIPTION
A few things in the logs directory don't clean up after themselves properly:

- packLogFiles copies the newest log to `<name>most_recent.log` right next to the real logs, and getSortedLogFiles globs `*.log`, so if that copy ever survives it gets treated as a real log and picks up the suffix again on the next run
- the copy only gets deleted on the happy path, so a failed pack leaves it behind
- the zip removal after upload isn't awaited, and doesn't happen at all if the upload throws

First commit pulls the log file name into its own small module so the logger and the log service aren't each carrying their own idea of the format. That lets the service tell real run logs apart from anything else sitting in the folder. There's a test that fails if the name the logger builds stops matching what the service filters on, which felt better than a comment asking people to keep the two in sync.

Second commit uses that to filter, moves the copy cleanup into a finally, and awaits the zip removal.

Related to #610. I couldn't tell how much of what's in the screenshot there this accounts for, so I'd treat it as tidying rather than a fix for that report.

Developed with Claude Code.
