### PR TITLE
Preserve Tachyon failure details across IPC

### DIFF
--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -67,6 +67,10 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     ipcMain.handle("tachyon:request", async (_event, command, args) => {
         return await tachyonClient.request(command, args);
     });
+
+    ipcMain.handle("tachyon:requestStructured", async (_event, command, args) => {
+        return await tachyonClient.requestStructured(command, args);
+    });
 }
 
 export const tachyonService = {

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -112,24 +112,22 @@ export class TachyonClient {
         });
     }
 
-    public async request<C extends GetCommandIds<"user", "server", "request">>(
-        ...args: GetCommandData<GetCommands<"user", "server", "request", C>> extends never ? [commandId: C] : [commandId: C, data: GetCommandData<GetCommands<"user", "server", "request", C>>]
-    ): Promise<Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>> {
+    private async sendRequest(commandId: string, data?: unknown): Promise<TachyonResponse> {
         if (!this.socket) {
             throw new Error("Not connected to server");
         }
-        const [commandId, data] = args as [C, GetCommandData<GetCommands<"user", "server", "request", C>> | undefined];
         const messageId = randomUUID();
         const request = {
             type: "request",
             commandId,
             messageId,
-        } as GetCommands<"user", "server", "request", C>;
+        } as TachyonRequest;
         if (data) {
             Object.assign(request, { data });
         }
         validateCommand(request);
         this.socket.send(JSON.stringify(request));
+
         return new Promise((resolve, reject) => {
             this.responseHandlers.set(messageId, (response: TachyonResponse | { status: "socket_closed" }) => {
                 if (response.status === "socket_closed") {
@@ -139,12 +137,31 @@ export class TachyonClient {
                 }
                 if (response.status === "failed") {
                     log.error(`Error response received: ${JSON.stringify(response)}`);
-                    reject(new Error(`${response.reason}` + (response.details ? ` (${response.details})` : "")));
-                    return;
                 }
-                resolve(response as Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>);
+                resolve(response);
             });
         });
+    }
+
+    public async requestStructured<C extends GetCommandIds<"user", "server", "request">>(
+        ...args: GetCommandData<GetCommands<"user", "server", "request", C>> extends never ? [commandId: C] : [commandId: C, data: GetCommandData<GetCommands<"user", "server", "request", C>>]
+    ): Promise<GetCommands<"server", "user", "response", C>> {
+        const [commandId, data] = args as [C, unknown];
+        const response = await this.sendRequest(commandId, data);
+
+        return response as GetCommands<"server", "user", "response", C>;
+    }
+
+    public async request<C extends GetCommandIds<"user", "server", "request">>(
+        ...args: GetCommandData<GetCommands<"user", "server", "request", C>> extends never ? [commandId: C] : [commandId: C, data: GetCommandData<GetCommands<"user", "server", "request", C>>]
+    ): Promise<Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>> {
+        const [commandId, data] = args as [C, unknown];
+        const response = await this.sendRequest(commandId, data);
+        if (response.status === "failed") {
+            throw new Error(`${response.reason}` + (response.details ? ` (${response.details})` : ""));
+        }
+
+        return response as Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>;
     }
 
     public sendEvent(event: TachyonEvent) {

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -118,6 +118,7 @@ export type IPCCommands = {
     "tachyon:isConnected": () => boolean;
     "tachyon:sendEvent": (event: TachyonEvent) => void;
     "tachyon:request": (...args: unknown[]) => Promise<TachyonResponse>;
+    "tachyon:requestStructured": (...args: unknown[]) => Promise<TachyonResponse>;
 };
 
 type Awaitable<T> = T | Promise<T>;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -200,6 +200,14 @@ function request<C extends GetCommandIds<"user", "server", "request">>(
     return ipcRenderer.invoke("tachyon:request", ...args) as Promise<Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>>;
 }
 
+// Protocol failures must not cross the context bridge as thrown Errors, which would strip the
+// failure reason and details. The renderer wrapper in @renderer/api/tachyon rebuilds the error.
+function requestStructured<C extends GetCommandIds<"user", "server", "request">>(
+    ...args: GetCommandData<GetCommands<"user", "server", "request", C>> extends never ? [commandId: C] : [commandId: C, data: GetCommandData<GetCommands<"user", "server", "request", C>>]
+): Promise<GetCommands<"server", "user", "response", C>> {
+    return ipcRenderer.invoke("tachyon:requestStructured", ...args) as Promise<GetCommands<"server", "user", "response", C>>;
+}
+
 function onEvent<C extends GetCommandIds<"server", "user", "event">>(eventID: C, callback: (event: GetCommandData<GetCommands<"server", "user", "event", C>>) => void) {
     ipcRenderer.setMaxListeners(30);
 
@@ -224,6 +232,7 @@ const tachyonApi = {
     // Requests
     // sendEvent: (event: TachyonEvent) => ipcRenderer.invoke("tachyon:sendEvent", event),
     request,
+    requestStructured,
 
     // Events
     onConnected: (callback: () => void) => ipcRenderer.on("tachyon:connected", callback),

--- a/src/renderer/api/tachyon.ts
+++ b/src/renderer/api/tachyon.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { GetCommandData, GetCommandIds, GetCommands, TachyonResponse } from "tachyon-protocol";
+
+type RequestCommandId = GetCommandIds<"user", "server", "request">;
+type SuccessResponse<C extends RequestCommandId> = Extract<GetCommands<"server", "user", "response", C>, { status: "success" }>;
+type FailedResponse<C extends RequestCommandId> = Extract<GetCommands<"server", "user", "response", C>, { status: "failed" }>;
+type AnyFailedResponse = Extract<TachyonResponse, { status: "failed" }>;
+
+export class TachyonRequestError<C extends RequestCommandId = RequestCommandId> extends Error {
+    readonly commandId: C;
+    readonly reason: FailedResponse<C>["reason"];
+    readonly details?: string;
+
+    constructor(commandId: C, response: AnyFailedResponse) {
+        super(`${commandId} failed: ${response.reason}` + (response.details ? ` (${response.details})` : ""));
+        this.name = "TachyonRequestError";
+        this.commandId = commandId;
+        this.reason = response.reason as FailedResponse<C>["reason"];
+        this.details = response.details;
+    }
+}
+
+export async function tachyonRequest<C extends RequestCommandId>(
+    ...args: GetCommandData<GetCommands<"user", "server", "request", C>> extends never ? [commandId: C] : [commandId: C, data: GetCommandData<GetCommands<"user", "server", "request", C>>]
+): Promise<SuccessResponse<C>> {
+    const [commandId] = args as [C];
+    const requestStructured = window.tachyon.requestStructured as (...args: unknown[]) => Promise<TachyonResponse>;
+    const response = await requestStructured(...args);
+    if (response.status === "failed") {
+        throw new TachyonRequestError(commandId, response);
+    }
+
+    return response as SuccessResponse<C>;
+}
+
+export function isTachyonErrorForCommand<C extends RequestCommandId>(error: unknown, commandId: C): error is TachyonRequestError<C> {
+    return error instanceof TachyonRequestError && error.commandId === commandId;
+}

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -14,6 +14,7 @@ import {
 import { tachyonStore } from "@renderer/store/tachyon.store";
 import { db } from "@renderer/store/db";
 import { notificationsApi } from "@renderer/api/notifications";
+import { isTachyonErrorForCommand, tachyonRequest } from "@renderer/api/tachyon";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
 
@@ -188,13 +189,13 @@ async function sendQueueRequest() {
             matchmakingStore.status = MatchmakingStatus.Idle;
             return;
         }
-        const response = await window.tachyon.request("matchmaking/queue", {
+        const response = await tachyonRequest("matchmaking/queue", {
             queues: [{ id: playlist.id, version: playlist.version }],
         });
         console.log("Tachyon: matchmaking/queue:", response.status);
         matchmakingStore.status = MatchmakingStatus.Searching;
     } catch (error) {
-        if (error instanceof Error && error.message.includes("version_mismatch")) {
+        if (isTachyonErrorForCommand(error, "matchmaking/queue") && error.reason === "version_mismatch") {
             notificationsApi.alert({ text: "Queue version changed; refreshing list.", severity: "info" });
             await sendListRequest();
         } else {

--- a/tests/unit/renderer/tachyon-request.spec.ts
+++ b/tests/unit/renderer/tachyon-request.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { isTachyonErrorForCommand, TachyonRequestError, tachyonRequest } from "@renderer/api/tachyon";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requestStructured = vi.fn();
+window.tachyon.requestStructured = requestStructured as unknown as typeof window.tachyon.requestStructured;
+
+describe("tachyonRequest", () => {
+    beforeEach(() => {
+        requestStructured.mockReset();
+    });
+
+    it("returns the success response", async () => {
+        const response = { type: "response", commandId: "matchmaking/cancel", messageId: "1", status: "success" };
+        requestStructured.mockResolvedValue(response);
+
+        await expect(tachyonRequest("matchmaking/cancel")).resolves.toBe(response);
+    });
+
+    it("throws a TachyonRequestError carrying the reason and details", async () => {
+        requestStructured.mockResolvedValue({
+            type: "response",
+            commandId: "matchmaking/queue",
+            messageId: "1",
+            status: "failed",
+            reason: "version_mismatch",
+            details: "queue was updated",
+        });
+
+        const error = await tachyonRequest("matchmaking/queue", { queues: [{ id: "1v1", version: "2" }] }).catch((error: unknown) => error);
+
+        expect(error).toBeInstanceOf(TachyonRequestError);
+        expect((error as TachyonRequestError).reason).toBe("version_mismatch");
+        expect((error as TachyonRequestError).details).toBe("queue was updated");
+    });
+
+    it("only matches the command the error came from", async () => {
+        requestStructured.mockResolvedValue({
+            type: "response",
+            commandId: "matchmaking/queue",
+            messageId: "1",
+            status: "failed",
+            reason: "version_mismatch",
+        });
+
+        const error = await tachyonRequest("matchmaking/queue", { queues: [{ id: "1v1", version: "2" }] }).catch((error: unknown) => error);
+
+        expect(isTachyonErrorForCommand(error, "matchmaking/queue")).toBe(true);
+        expect(isTachyonErrorForCommand(error, "matchmaking/cancel")).toBe(false);
+    });
+
+    it("leaves IPC errors alone", async () => {
+        requestStructured.mockRejectedValue(new Error("Not connected to server"));
+
+        const error = await tachyonRequest("matchmaking/cancel").catch((error: unknown) => error);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(isTachyonErrorForCommand(error, "matchmaking/cancel")).toBe(false);
+    });
+});

--- a/tests/unit/shared/preload-api-context-bridge.spec.ts
+++ b/tests/unit/shared/preload-api-context-bridge.spec.ts
@@ -266,6 +266,7 @@ describe("Preload API Context Bridge", () => {
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("tachyon:connect");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("tachyon:disconnect");
         expect(typeof mockWindow.tachyon.request).toBe("function");
+        expect(typeof mockWindow.tachyon.requestStructured).toBe("function");
         expect(typeof mockWindow.tachyon.onConnected).toBe("function");
         expect(typeof mockWindow.tachyon.onDisconnected).toBe("function");
         expect(typeof mockWindow.tachyon.onEvent).toBe("function");


### PR DESCRIPTION
Closes #588.

There are two request functions now rather than a fix to the existing one, because throwing can only carry a string. The renderer would have to pick the reason back out of the message text, which is the fragile bit in the first place. Not throwing is the only way to hand over something structured.

Only matchmaking/queue uses the new one, since it was the one doing the string matching. The rest are untouched.

Tests, typecheck and lint pass. I haven't run it against a live server, so I haven't actually watched the version mismatch case happen.

AI disclosure: written with Claude Code. I directed the approach and reviewed the diff.
