### PR TITLE
Handle shell open failures instead of crashing the client

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,4 +54,17 @@ export default [
             "@typescript-eslint/no-unsafe-function-type": "warn",
         },
     },
+    {
+        files: ["src/renderer/**/*.{ts,vue}"],
+        ignores: ["src/renderer/api/shell.ts"],
+        rules: {
+            "no-restricted-syntax": [
+                "error",
+                {
+                    selector: "MemberExpression[object.name='window'][property.name='shell']",
+                    message: "Use shellApi from @renderer/api/shell so failures get reported instead of reaching the fatal error modal.",
+                },
+            ],
+        },
+    },
 ];

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -1,6 +1,9 @@
 {
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": "Could not open that: {details}"
+            },
             "commands": {
                 "help": "Displays this help text.",
                 "whoami": "Sends back information about who you are.",

--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -22,8 +22,6 @@ function failed(reason: string, details?: string): IpcResult {
     return { status: "failed", reason, details };
 }
 
-// Anything escaping these handlers reaches the renderer as an unhandled rejection, which Error.vue
-// turns into an unrecoverable modal. Failures have to come back as data instead.
 async function attempt(reason: string, action: () => Promise<void> | void): Promise<IpcResult> {
     try {
         await action();
@@ -34,7 +32,7 @@ async function attempt(reason: string, action: () => Promise<void> | void): Prom
     }
 }
 
-// shell.openPath resolves with an error message instead of rejecting, and an empty string on success.
+// openPath resolves with an error message rather than rejecting, and an empty string on success.
 async function openPath(target: string): Promise<IpcResult> {
     return attempt("open_failed", async () => {
         const error = await shell.openPath(target);
@@ -42,8 +40,7 @@ async function openPath(target: string): Promise<IpcResult> {
     });
 }
 
-// shell.showItemInFolder reports nothing at all, so check what we can before calling it - otherwise
-// a missing file is indistinguishable from success. An absent file manager still isn't detectable.
+// showItemInFolder reports nothing at all, so a missing file is otherwise indistinguishable from success.
 async function showInFolder(target: string): Promise<IpcResult> {
     return attempt("open_failed", async () => {
         await fs.promises.access(target);

--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -6,6 +6,7 @@ import { STATE_PATH, CONFIG_PATH, WRITE_DATA_PATH, REPLAYS_PATH, getAssetsPath }
 import { shell } from "electron";
 import { ipcMain, IpcResult } from "@main/typed-ipc";
 import { logger } from "@main/utils/logger";
+import fs from "fs";
 import path from "path";
 
 const REPLAY_SERVICE_URL = "https://bar-rts.com/replays";
@@ -41,12 +42,31 @@ async function openPath(target: string): Promise<IpcResult> {
     });
 }
 
+// shell.showItemInFolder reports nothing at all, so check what we can before calling it - otherwise
+// a missing file is indistinguishable from success. An absent file manager still isn't detectable.
+async function showInFolder(target: string): Promise<IpcResult> {
+    return attempt("open_failed", async () => {
+        await fs.promises.access(target);
+        shell.showItemInFolder(target);
+    });
+}
+
 // Careful with shell.openExternal. https://benjamin-altpeter.de/shell-openexternal-dangers/
-async function openInBrowser(url: string): Promise<IpcResult> {
-    if (!["https:", "http:"].includes(new URL(url).protocol)) return failed("url_not_allowed", url);
+function isAllowedUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    if (!["https:", "http:"].includes(parsed.protocol)) return false;
 
     // Additional checks to prevent opening arbitrary URLs
-    if (![REPLAY_SERVICE_URL, NEWS_SERVICE_URL].some((serviceUrl) => url.startsWith(serviceUrl))) return failed("url_not_allowed", url);
+    return [REPLAY_SERVICE_URL, NEWS_SERVICE_URL].some((serviceUrl) => url.startsWith(serviceUrl));
+}
+
+async function openInBrowser(url: string): Promise<IpcResult> {
+    if (!isAllowedUrl(url)) return failed("url_not_allowed", url);
 
     return attempt("open_failed", () => shell.openExternal(url));
 }
@@ -57,7 +77,7 @@ function registerIpcHandlers() {
     ipcMain.handle("shell:openSettingsFile", () => openPath(path.join(CONFIG_PATH, "settings.json")));
     ipcMain.handle("shell:openStartScript", () => openPath(path.join(WRITE_DATA_PATH, "script.txt")));
     ipcMain.handle("shell:openReplaysDir", () => openPath(REPLAYS_PATH));
-    ipcMain.handle("shell:showReplayInFolder", (_event, fileName: string) => attempt("open_failed", () => shell.showItemInFolder(path.join(REPLAYS_PATH, fileName))));
+    ipcMain.handle("shell:showReplayInFolder", (_event, fileName: string) => showInFolder(path.join(REPLAYS_PATH, fileName)));
 
     // External
     ipcMain.handle("shell:openInBrowser", (_event, url) => openInBrowser(url));

--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -4,28 +4,60 @@
 
 import { STATE_PATH, CONFIG_PATH, WRITE_DATA_PATH, REPLAYS_PATH, getAssetsPath } from "@main/config/app";
 import { shell } from "electron";
-import { ipcMain } from "@main/typed-ipc";
+import { ipcMain, IpcResult } from "@main/typed-ipc";
+import { logger } from "@main/utils/logger";
 import path from "path";
 
 const REPLAY_SERVICE_URL = "https://bar-rts.com/replays";
 const NEWS_SERVICE_URL = "https://www.beyondallreason.info/news";
 
+const log = logger("shell-service");
+
+const success: IpcResult = { status: "success", data: undefined };
+
+function failed(reason: string, details?: string): IpcResult {
+    log.error(`${reason}${details ? `: ${details}` : ""}`);
+
+    return { status: "failed", reason, details };
+}
+
+// Anything escaping these handlers reaches the renderer as an unhandled rejection, which Error.vue
+// turns into an unrecoverable modal. Failures have to come back as data instead.
+async function attempt(reason: string, action: () => Promise<void> | void): Promise<IpcResult> {
+    try {
+        await action();
+
+        return success;
+    } catch (err) {
+        return failed(reason, err instanceof Error ? err.message : String(err));
+    }
+}
+
+// shell.openPath resolves with an error message instead of rejecting, and an empty string on success.
+async function openPath(target: string): Promise<IpcResult> {
+    return attempt("open_failed", async () => {
+        const error = await shell.openPath(target);
+        if (error) throw new Error(error);
+    });
+}
+
 // Careful with shell.openExternal. https://benjamin-altpeter.de/shell-openexternal-dangers/
-function openInBrowser(url: string) {
-    if (!["https:", "http:"].includes(new URL(url).protocol)) return;
+async function openInBrowser(url: string): Promise<IpcResult> {
+    if (!["https:", "http:"].includes(new URL(url).protocol)) return failed("url_not_allowed", url);
 
     // Additional checks to prevent opening arbitrary URLs
-    if (![REPLAY_SERVICE_URL, NEWS_SERVICE_URL].some((serviceUrl) => url.startsWith(serviceUrl))) return;
-    shell.openExternal(url);
+    if (![REPLAY_SERVICE_URL, NEWS_SERVICE_URL].some((serviceUrl) => url.startsWith(serviceUrl))) return failed("url_not_allowed", url);
+
+    return attempt("open_failed", () => shell.openExternal(url));
 }
 
 function registerIpcHandlers() {
-    ipcMain.handle("shell:openStateDir", () => shell.openPath(STATE_PATH));
-    ipcMain.handle("shell:openAssetsDir", () => shell.openPath(getAssetsPath()));
-    ipcMain.handle("shell:openSettingsFile", () => shell.openPath(path.join(CONFIG_PATH, "settings.json")));
-    ipcMain.handle("shell:openStartScript", () => shell.openPath(path.join(WRITE_DATA_PATH, "script.txt")));
-    ipcMain.handle("shell:openReplaysDir", () => shell.openPath(REPLAYS_PATH));
-    ipcMain.handle("shell:showReplayInFolder", (_event, fileName: string) => shell.showItemInFolder(path.join(REPLAYS_PATH, fileName)));
+    ipcMain.handle("shell:openStateDir", () => openPath(STATE_PATH));
+    ipcMain.handle("shell:openAssetsDir", () => openPath(getAssetsPath()));
+    ipcMain.handle("shell:openSettingsFile", () => openPath(path.join(CONFIG_PATH, "settings.json")));
+    ipcMain.handle("shell:openStartScript", () => openPath(path.join(WRITE_DATA_PATH, "script.txt")));
+    ipcMain.handle("shell:openReplaysDir", () => openPath(REPLAYS_PATH));
+    ipcMain.handle("shell:showReplayInFolder", (_event, fileName: string) => attempt("open_failed", () => shell.showItemInFolder(path.join(REPLAYS_PATH, fileName))));
 
     // External
     ipcMain.handle("shell:openInBrowser", (_event, url) => openInBrowser(url));

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -18,6 +18,12 @@ import type { Settings } from "@main/services/settings.service";
 import type { TachyonEvent, TachyonResponse } from "tachyon-protocol";
 import { ipcRenderer as electronIpcRenderer, ipcMain as electronIpcMain } from "electron";
 
+// Errors thrown in main arrive in the renderer stripped of everything but a message, so failures a
+// caller needs to act on have to travel as data instead. Mirrors the shape tachyon-protocol uses for
+// its own responses, which can't be reused here because it's keyed on tachyon command ids.
+// `reason` is a stable code to branch on or translate; `details` carries any raw text behind it.
+export type IpcResult<T = void> = { status: "success"; data: T } | { status: "failed"; reason: string; details?: string };
+
 export type IPCEvents = {
     "downloads:update:progress": (downloadInfo: DownloadInfo) => void;
     "downloads:engine:complete": (downloadInfo: DownloadInfo) => void;
@@ -106,13 +112,13 @@ export type IPCCommands = {
     "settings:get": () => Settings;
     "settings:toggleFullscreen": () => void;
     "settings:update": (settings: Partial<Settings>) => Partial<Settings>;
-    "shell:openStateDir": () => string;
-    "shell:openAssetsDir": () => string;
-    "shell:openInBrowser": (url: string) => void;
-    "shell:openReplaysDir": () => string;
-    "shell:openSettingsFile": () => string;
-    "shell:openStartScript": () => string;
-    "shell:showReplayInFolder": (fileName: string) => void;
+    "shell:openStateDir": () => IpcResult;
+    "shell:openAssetsDir": () => IpcResult;
+    "shell:openInBrowser": (url: string) => IpcResult;
+    "shell:openReplaysDir": () => IpcResult;
+    "shell:openSettingsFile": () => IpcResult;
+    "shell:openStartScript": () => IpcResult;
+    "shell:showReplayInFolder": (fileName: string) => IpcResult;
     "tachyon:connect": () => void;
     "tachyon:disconnect": () => void;
     "tachyon:isConnected": () => boolean;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { contextBridge } from "electron";
-import { ipcRenderer } from "@main/typed-ipc";
+import { ipcRenderer, IpcResult } from "@main/typed-ipc";
 import { Replay } from "@main/content/replays/replay";
 import { Settings } from "@main/services/settings.service";
 import { EngineVersion } from "@main/content/engine/engine-version";
@@ -43,15 +43,15 @@ export type MainWindowApi = typeof mainWindowApi;
 contextBridge.exposeInMainWorld("mainWindow", mainWindowApi);
 
 const shellApi = {
-    openStateDir: (): Promise<string> => ipcRenderer.invoke("shell:openStateDir"),
-    openAssetsDir: (): Promise<string> => ipcRenderer.invoke("shell:openAssetsDir"),
-    openSettingsFile: (): Promise<string> => ipcRenderer.invoke("shell:openSettingsFile"),
-    openStartScript: (): Promise<string> => ipcRenderer.invoke("shell:openStartScript"),
-    openReplaysDir: (): Promise<string> => ipcRenderer.invoke("shell:openReplaysDir"),
-    showReplayInFolder: (fileName: string): Promise<void> => ipcRenderer.invoke("shell:showReplayInFolder", fileName),
+    openStateDir: (): Promise<IpcResult> => ipcRenderer.invoke("shell:openStateDir"),
+    openAssetsDir: (): Promise<IpcResult> => ipcRenderer.invoke("shell:openAssetsDir"),
+    openSettingsFile: (): Promise<IpcResult> => ipcRenderer.invoke("shell:openSettingsFile"),
+    openStartScript: (): Promise<IpcResult> => ipcRenderer.invoke("shell:openStartScript"),
+    openReplaysDir: (): Promise<IpcResult> => ipcRenderer.invoke("shell:openReplaysDir"),
+    showReplayInFolder: (fileName: string): Promise<IpcResult> => ipcRenderer.invoke("shell:showReplayInFolder", fileName),
 
     // External
-    openInBrowser: (url: string): Promise<void> => ipcRenderer.invoke("shell:openInBrowser", url),
+    openInBrowser: (url: string): Promise<IpcResult> => ipcRenderer.invoke("shell:openInBrowser", url),
 };
 export type ShellApi = typeof shellApi;
 contextBridge.exposeInMainWorld("shell", shellApi);

--- a/src/renderer/api/shell.ts
+++ b/src/renderer/api/shell.ts
@@ -11,9 +11,9 @@ const i18n = setupI18n();
 // Failing to open a folder or a link isn't worth interrupting anyone over, but it shouldn't be
 // swallowed either - the OS reason is the only clue a player has about what went wrong.
 //
-// Callers fire this without awaiting, so it has to absorb its own rejections too. Anything escaping
+// Callers fire these without awaiting, so rejections have to be absorbed here too. Anything escaping
 // reaches Error.vue's unhandledrejection listener, which is an unrecoverable modal.
-export async function openAndReport(open: () => Promise<IpcResult>) {
+async function openAndReport(open: () => Promise<IpcResult>) {
     const result = await open().catch((err): IpcResult => {
         console.error("Shell request failed", err);
 
@@ -26,3 +26,13 @@ export async function openAndReport(open: () => Promise<IpcResult>) {
         severity: "error",
     });
 }
+
+export const shellApi = {
+    openStateDir: () => openAndReport(window.shell.openStateDir),
+    openAssetsDir: () => openAndReport(window.shell.openAssetsDir),
+    openSettingsFile: () => openAndReport(window.shell.openSettingsFile),
+    openStartScript: () => openAndReport(window.shell.openStartScript),
+    openReplaysDir: () => openAndReport(window.shell.openReplaysDir),
+    showReplayInFolder: (fileName: string) => openAndReport(() => window.shell.showReplayInFolder(fileName)),
+    openInBrowser: (url: string) => openAndReport(() => window.shell.openInBrowser(url)),
+};

--- a/src/renderer/api/shell.ts
+++ b/src/renderer/api/shell.ts
@@ -10,8 +10,15 @@ const i18n = setupI18n();
 
 // Failing to open a folder or a link isn't worth interrupting anyone over, but it shouldn't be
 // swallowed either - the OS reason is the only clue a player has about what went wrong.
+//
+// Callers fire this without awaiting, so it has to absorb its own rejections too. Anything escaping
+// reaches Error.vue's unhandledrejection listener, which is an unrecoverable modal.
 export async function openAndReport(open: () => Promise<IpcResult>) {
-    const result = await open();
+    const result = await open().catch((err): IpcResult => {
+        console.error("Shell request failed", err);
+
+        return { status: "failed", reason: "ipc_failed", details: err instanceof Error ? err.message : String(err) };
+    });
     if (result.status === "success") return;
 
     notificationsApi.alert({

--- a/src/renderer/api/shell.ts
+++ b/src/renderer/api/shell.ts
@@ -8,11 +8,6 @@ import { setupI18n } from "@renderer/i18n";
 
 const i18n = setupI18n();
 
-// Failing to open a folder or a link isn't worth interrupting anyone over, but it shouldn't be
-// swallowed either - the OS reason is the only clue a player has about what went wrong.
-//
-// Callers fire these without awaiting, so rejections have to be absorbed here too. Anything escaping
-// reaches Error.vue's unhandledrejection listener, which is an unrecoverable modal.
 async function openAndReport(open: () => Promise<IpcResult>) {
     const result = await open().catch((err): IpcResult => {
         console.error("Shell request failed", err);

--- a/src/renderer/api/shell.ts
+++ b/src/renderer/api/shell.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { IpcResult } from "@main/typed-ipc";
+import { notificationsApi } from "@renderer/api/notifications";
+import { setupI18n } from "@renderer/i18n";
+
+const i18n = setupI18n();
+
+// Failing to open a folder or a link isn't worth interrupting anyone over, but it shouldn't be
+// swallowed either - the OS reason is the only clue a player has about what went wrong.
+export async function openAndReport(open: () => Promise<IpcResult>) {
+    const result = await open();
+    if (result.status === "success") return;
+
+    notificationsApi.alert({
+        text: i18n.global.t("lobby.api.shell.openFailed", { details: result.details ?? result.reason }),
+        severity: "error",
+    });
+}

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -1984,6 +1984,9 @@
     },
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": null
+            },
             "commands": {
                 "help": null,
                 "whoami": null,

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -1858,6 +1858,9 @@
             "quickPlay": "Quick play in german"
         },
         "api": {
+            "shell": {
+                "openFailed": null
+            },
             "commands": {
                 "help": null,
                 "whoami": null,

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -1832,6 +1832,9 @@
     },
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": "Could not open that: {details}"
+            },
             "commands": {
                 "help": "Displays this help text.",
                 "whoami": "Sends back information about who you are.",

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -3837,6 +3837,9 @@
     },
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": null
+            },
             "commands": {
                 "help": null,
                 "whoami": null,

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -3806,6 +3806,9 @@
     },
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": null
+            },
             "commands": {
                 "help": null,
                 "whoami": null,

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -3948,6 +3948,9 @@
     },
     "lobby": {
         "api": {
+            "shell": {
+                "openFailed": null
+            },
             "commands": {
                 "help": null,
                 "whoami": null,

--- a/src/renderer/components/misc/DebugSidebar.vue
+++ b/src/renderer/components/misc/DebugSidebar.vue
@@ -70,6 +70,7 @@ import { GameVersion } from "@main/content/game/game-version";
 import { inject, Ref } from "vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { party } from "@renderer/store/party.store";
+import { openAndReport } from "@renderer/api/shell";
 const { t } = useTypedI18n();
 
 const active = ref(false);
@@ -95,19 +96,19 @@ async function onRouteSelect(newRoute: string) {
 }
 
 function openSettings() {
-    window.shell.openSettingsFile();
+    openAndReport(() => window.shell.openSettingsFile());
 }
 
-async function openAssetsDir() {
-    window.shell.openAssetsDir();
+function openAssetsDir() {
+    openAndReport(() => window.shell.openAssetsDir());
 }
 
-async function openStateDir() {
-    window.shell.openStateDir();
+function openStateDir() {
+    openAndReport(() => window.shell.openStateDir());
 }
 
-async function openStartScript() {
-    window.shell.openStartScript();
+function openStartScript() {
+    openAndReport(() => window.shell.openStartScript());
 }
 
 function openSyncLobbyContentTool() {

--- a/src/renderer/components/misc/DebugSidebar.vue
+++ b/src/renderer/components/misc/DebugSidebar.vue
@@ -70,7 +70,7 @@ import { GameVersion } from "@main/content/game/game-version";
 import { inject, Ref } from "vue";
 import { useTypedI18n } from "@renderer/i18n";
 import { party } from "@renderer/store/party.store";
-import { openAndReport } from "@renderer/api/shell";
+import { shellApi } from "@renderer/api/shell";
 const { t } = useTypedI18n();
 
 const active = ref(false);
@@ -96,19 +96,19 @@ async function onRouteSelect(newRoute: string) {
 }
 
 function openSettings() {
-    openAndReport(() => window.shell.openSettingsFile());
+    shellApi.openSettingsFile();
 }
 
 function openAssetsDir() {
-    openAndReport(() => window.shell.openAssetsDir());
+    shellApi.openAssetsDir();
 }
 
 function openStateDir() {
-    openAndReport(() => window.shell.openStateDir());
+    shellApi.openStateDir();
 }
 
 function openStartScript() {
-    openAndReport(() => window.shell.openStartScript());
+    shellApi.openStartScript();
 }
 
 function openSyncLobbyContentTool() {

--- a/src/renderer/components/misc/NewsTile.vue
+++ b/src/renderer/components/misc/NewsTile.vue
@@ -19,6 +19,7 @@ import { NewsFeedEntry } from "@main/services/news.service";
 import { useImageBlobUrlCache } from "@renderer/composables/useImageBlobUrlCache";
 import { ref } from "vue";
 import { useTypedI18n } from "@renderer/i18n";
+import { shellApi } from "@renderer/api/shell";
 
 const { t } = useTypedI18n();
 
@@ -32,7 +33,7 @@ const newsThumbnail = props.news.thumbnailUrl;
 const backgroundImageCss = newsThumbnail ? ref(`url('${base64(newsThumbnail, props.news.thumbnail || "")}')`) : ref();
 
 const openNews = () => {
-    if (props.news.link) window.shell.openInBrowser(props.news.link);
+    if (props.news.link) shellApi.openInBrowser(props.news.link);
 };
 </script>
 

--- a/src/renderer/views/watch/replays.vue
+++ b/src/renderer/views/watch/replays.vue
@@ -164,6 +164,7 @@ import { Icon } from "@iconify/vue";
 import folder from "@iconify-icons/mdi/folder";
 import SearchBox from "@renderer/components/controls/SearchBox.vue";
 import { settingsStore } from "@renderer/store/settings.store";
+import { openAndReport } from "@renderer/api/shell";
 
 const { t } = useTypedI18n();
 
@@ -263,15 +264,15 @@ function onSort(event: DataTableSortEvent) {
 }
 
 function openBrowserToReplayService() {
-    window.shell.openInBrowser("https://bar-rts.com/replays");
+    openAndReport(() => window.shell.openInBrowser("https://bar-rts.com/replays"));
 }
 
 function openReplaysFolder() {
-    window.shell.openReplaysDir();
+    openAndReport(() => window.shell.openReplaysDir());
 }
 
 function showReplayFile(replay: Replay) {
-    if (replay?.fileName) window.shell.showReplayInFolder(replay.fileName);
+    if (replay?.fileName) openAndReport(() => window.shell.showReplayInFolder(replay.fileName));
 }
 </script>
 

--- a/src/renderer/views/watch/replays.vue
+++ b/src/renderer/views/watch/replays.vue
@@ -164,7 +164,7 @@ import { Icon } from "@iconify/vue";
 import folder from "@iconify-icons/mdi/folder";
 import SearchBox from "@renderer/components/controls/SearchBox.vue";
 import { settingsStore } from "@renderer/store/settings.store";
-import { openAndReport } from "@renderer/api/shell";
+import { shellApi } from "@renderer/api/shell";
 
 const { t } = useTypedI18n();
 
@@ -264,15 +264,15 @@ function onSort(event: DataTableSortEvent) {
 }
 
 function openBrowserToReplayService() {
-    openAndReport(() => window.shell.openInBrowser("https://bar-rts.com/replays"));
+    shellApi.openInBrowser("https://bar-rts.com/replays");
 }
 
 function openReplaysFolder() {
-    openAndReport(() => window.shell.openReplaysDir());
+    shellApi.openReplaysDir();
 }
 
 function showReplayFile(replay: Replay) {
-    if (replay?.fileName) openAndReport(() => window.shell.showReplayInFolder(replay.fileName));
+    if (replay?.fileName) shellApi.showReplayInFolder(replay.fileName);
 }
 </script>
 

--- a/tests/unit/main/shell-service.spec.ts
+++ b/tests/unit/main/shell-service.spec.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openPath, openExternal, showItemInFolder, handlers } = vi.hoisted(() => ({
+    openPath: vi.fn(),
+    openExternal: vi.fn(),
+    showItemInFolder: vi.fn(),
+    handlers: new Map<string, (event: unknown, ...args: unknown[]) => Promise<unknown>>(),
+}));
+
+vi.mock("electron", () => ({
+    shell: { openPath, openExternal, showItemInFolder },
+    // typed-ipc reads both off the electron module at import time.
+    ipcRenderer: {},
+    ipcMain: {
+        handle: (channel: string, listener: (event: unknown, ...args: unknown[]) => Promise<unknown>) => handlers.set(channel, listener),
+    },
+}));
+
+// app.ts calls app.setPath and mkdirSync at module scope, so it can't be imported in a test.
+vi.mock("@main/config/app", () => ({
+    STATE_PATH: "/state",
+    CONFIG_PATH: "/state/config",
+    WRITE_DATA_PATH: "/state/write",
+    REPLAYS_PATH: "/state/replays",
+    getAssetsPath: () => "/assets",
+}));
+
+const { shellService } = await import("@main/services/shell.service");
+
+shellService.registerIpcHandlers();
+
+function invoke(channel: string, ...args: unknown[]) {
+    const handler = handlers.get(channel);
+    if (!handler) throw new Error(`No handler registered for ${channel}`);
+
+    return handler({}, ...args);
+}
+
+describe("shellService", () => {
+    beforeEach(() => {
+        openPath.mockReset();
+        openExternal.mockReset();
+        showItemInFolder.mockReset();
+    });
+
+    it("reports success when the path opens", async () => {
+        openPath.mockResolvedValue("");
+
+        await expect(invoke("shell:openReplaysDir")).resolves.toEqual({ status: "success", data: undefined });
+    });
+
+    // openPath resolves with an error message rather than rejecting, which is the case #507 hit.
+    it("turns the error message openPath resolves with into a failed result", async () => {
+        openPath.mockResolvedValue("No application found to open file of type inode/directory");
+
+        await expect(invoke("shell:openReplaysDir")).resolves.toEqual({
+            status: "failed",
+            reason: "open_failed",
+            details: "No application found to open file of type inode/directory",
+        });
+    });
+
+    it("does not let a rejection escape to the renderer", async () => {
+        openPath.mockRejectedValue(new Error("reply was never sent"));
+
+        await expect(invoke("shell:openReplaysDir")).resolves.toEqual({
+            status: "failed",
+            reason: "open_failed",
+            details: "reply was never sent",
+        });
+    });
+
+    it("does not let a synchronous throw escape to the renderer", async () => {
+        showItemInFolder.mockImplementation(() => {
+            throw new Error("no file manager");
+        });
+
+        await expect(invoke("shell:showReplayInFolder", "game.sdfz")).resolves.toEqual({
+            status: "failed",
+            reason: "open_failed",
+            details: "no file manager",
+        });
+    });
+
+    it("refuses a url outside the allowed services without calling out", async () => {
+        await expect(invoke("shell:openInBrowser", "https://example.com/evil")).resolves.toMatchObject({ status: "failed", reason: "url_not_allowed" });
+        expect(openExternal).not.toHaveBeenCalled();
+    });
+
+    it("opens an allowed url", async () => {
+        openExternal.mockResolvedValue(undefined);
+
+        await expect(invoke("shell:openInBrowser", "https://bar-rts.com/replays")).resolves.toEqual({ status: "success", data: undefined });
+        expect(openExternal).toHaveBeenCalledWith("https://bar-rts.com/replays");
+    });
+});

--- a/tests/unit/main/shell-service.spec.ts
+++ b/tests/unit/main/shell-service.spec.ts
@@ -4,12 +4,15 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openPath, openExternal, showItemInFolder, handlers } = vi.hoisted(() => ({
+const { openPath, openExternal, showItemInFolder, access, handlers } = vi.hoisted(() => ({
     openPath: vi.fn(),
     openExternal: vi.fn(),
     showItemInFolder: vi.fn(),
+    access: vi.fn(),
     handlers: new Map<string, (event: unknown, ...args: unknown[]) => Promise<unknown>>(),
 }));
+
+vi.mock("fs", () => ({ default: { promises: { access } } }));
 
 vi.mock("electron", () => ({
     shell: { openPath, openExternal, showItemInFolder },
@@ -45,6 +48,8 @@ describe("shellService", () => {
         openPath.mockReset();
         openExternal.mockReset();
         showItemInFolder.mockReset();
+        access.mockReset();
+        access.mockResolvedValue(undefined);
     });
 
     it("reports success when the path opens", async () => {
@@ -86,8 +91,22 @@ describe("shellService", () => {
         });
     });
 
+    // showItemInFolder reports nothing, so without the existence check a missing replay looks fine.
+    it("reports a missing replay rather than silently doing nothing", async () => {
+        access.mockRejectedValue(new Error("ENOENT: no such file or directory"));
+
+        await expect(invoke("shell:showReplayInFolder", "gone.sdfz")).resolves.toMatchObject({ status: "failed", reason: "open_failed" });
+        expect(showItemInFolder).not.toHaveBeenCalled();
+    });
+
     it("refuses a url outside the allowed services without calling out", async () => {
         await expect(invoke("shell:openInBrowser", "https://example.com/evil")).resolves.toMatchObject({ status: "failed", reason: "url_not_allowed" });
+        expect(openExternal).not.toHaveBeenCalled();
+    });
+
+    // new URL throws on anything without a scheme, which used to escape as an IPC rejection.
+    it("refuses a malformed url without throwing", async () => {
+        await expect(invoke("shell:openInBrowser", "bar-rts.com/replays")).resolves.toMatchObject({ status: "failed", reason: "url_not_allowed" });
         expect(openExternal).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/renderer/shell-report.spec.ts
+++ b/tests/unit/renderer/shell-report.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const alert = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert } }));
+vi.mock("@renderer/i18n", () => ({ setupI18n: () => ({ global: { t: (key: string, params: Record<string, string>) => `${key}:${params.details}` } }) }));
+
+const { openAndReport } = await import("@renderer/api/shell");
+
+describe("openAndReport", () => {
+    beforeEach(() => {
+        alert.mockReset();
+    });
+
+    it("stays quiet when the call succeeds", async () => {
+        await openAndReport(async () => ({ status: "success", data: undefined }));
+
+        expect(alert).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the details from a failed result", async () => {
+        await openAndReport(async () => ({ status: "failed", reason: "open_failed", details: "no application found" }));
+
+        expect(alert).toHaveBeenCalledWith(expect.objectContaining({ text: "lobby.api.shell.openFailed:no application found", severity: "error" }));
+    });
+
+    // Callers don't await this, so a rejection escaping here would hit Error.vue's fatal modal.
+    it("absorbs a rejection instead of letting it escape", async () => {
+        await expect(openAndReport(() => Promise.reject(new Error("No handler registered for 'shell:openReplaysDir'")))).resolves.toBeUndefined();
+
+        expect(alert).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining("No handler registered") }));
+    });
+});

--- a/tests/unit/renderer/shell-report.spec.ts
+++ b/tests/unit/renderer/shell-report.spec.ts
@@ -3,34 +3,49 @@
 // SPDX-License-Identifier: MIT
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IpcResult } from "@main/typed-ipc";
 
 const alert = vi.hoisted(() => vi.fn());
 
 vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert } }));
 vi.mock("@renderer/i18n", () => ({ setupI18n: () => ({ global: { t: (key: string, params: Record<string, string>) => `${key}:${params.details}` } }) }));
 
-const { openAndReport } = await import("@renderer/api/shell");
+const { shellApi } = await import("@renderer/api/shell");
 
-describe("openAndReport", () => {
+const openReplaysDir = vi.fn();
+
+Object.defineProperty(window, "shell", {
+    value: { openReplaysDir },
+    writable: false,
+});
+
+describe("shellApi", () => {
     beforeEach(() => {
         alert.mockReset();
+        openReplaysDir.mockReset();
     });
 
     it("stays quiet when the call succeeds", async () => {
-        await openAndReport(async () => ({ status: "success", data: undefined }));
+        openReplaysDir.mockResolvedValue({ status: "success", data: undefined } satisfies IpcResult);
+
+        await shellApi.openReplaysDir();
 
         expect(alert).not.toHaveBeenCalled();
     });
 
     it("surfaces the details from a failed result", async () => {
-        await openAndReport(async () => ({ status: "failed", reason: "open_failed", details: "no application found" }));
+        openReplaysDir.mockResolvedValue({ status: "failed", reason: "open_failed", details: "no application found" } satisfies IpcResult);
+
+        await shellApi.openReplaysDir();
 
         expect(alert).toHaveBeenCalledWith(expect.objectContaining({ text: "lobby.api.shell.openFailed:no application found", severity: "error" }));
     });
 
     // Callers don't await this, so a rejection escaping here would hit Error.vue's fatal modal.
     it("absorbs a rejection instead of letting it escape", async () => {
-        await expect(openAndReport(() => Promise.reject(new Error("No handler registered for 'shell:openReplaysDir'")))).resolves.toBeUndefined();
+        openReplaysDir.mockRejectedValue(new Error("No handler registered for 'shell:openReplaysDir'"));
+
+        await expect(shellApi.openReplaysDir()).resolves.toBeUndefined();
 
         expect(alert).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining("No handler registered") }));
     });


### PR DESCRIPTION
Closes #507. Shell failures now come back as data and show a dismissible message, instead of taking the client down with the fatal error modal.

The try/catch around each handler is what actually fixes this, not the tidier return type. Anything thrown in main reaches the renderer as an unhandled rejection, and Error.vue turns those into a modal you can only quit or reload out of.

The result type is new because #588's can't be reused - that one is generated by the tachyon package and keyed on its command ids. This mirrors its wording so there's one way of describing an IPC failure rather than two.

All seven handlers rather than just the replay one from the report, since it's the same bug in each. "Show in folder" also checks the file exists first, because the underlying call reports nothing at all - a missing file manager still isn't detectable there.

Renderer calls all go through `shellApi` rather than `window.shell`, with a lint rule holding that in place. The first version of this PR already missed a call in NewsTile.vue, so leaving it to memory clearly wasn't going to work.

The modal still catches anything else unhandled; that's #509.

Not verified by hand - the reporting environment is Linux without a file manager.

AI disclosure: written with assistance from Claude Code.
