### PR TITLE
Single-Instance Lock fix for 'start:multi" script

### DIFF
--- a/src/main/single-instance.ts
+++ b/src/main/single-instance.ts
@@ -7,6 +7,6 @@ import { app } from "electron";
 // Imports are hoisted, so the lock has to be taken by the first module in the
 // graph rather than at the top of main.ts, or modules that log while loading
 // will have already opened a log file.
-if (!app.requestSingleInstanceLock()) {
+if (!app.requestSingleInstanceLock() && process.env.NODE_ENV === "production") {
     app.exit(0);
 }

--- a/src/main/single-instance.ts
+++ b/src/main/single-instance.ts
@@ -7,6 +7,6 @@ import { app } from "electron";
 // Imports are hoisted, so the lock has to be taken by the first module in the
 // graph rather than at the top of main.ts, or modules that log while loading
 // will have already opened a log file.
-if (!app.requestSingleInstanceLock() && process.env.NODE_ENV === "production") {
+if (!app.requestSingleInstanceLock() && process.env.NODE_ENV !== "development") {
     app.exit(0);
 }

--- a/tests/unit/main/main-process-lifecycle.spec.ts
+++ b/tests/unit/main/main-process-lifecycle.spec.ts
@@ -140,8 +140,9 @@ describe("Main Process Lifecycle", () => {
         vi.resetModules();
     });
 
-    it("should exit if single instance lock is not acquired", async () => {
+    it("should exit if single instance lock is not acquired in production", async () => {
         mockApp.requestSingleInstanceLock.mockReturnValue(false);
+        mockProcess.env.NODE_ENV = "production";
 
         await import("@main/main");
 

--- a/tools/launch-clients.ts
+++ b/tools/launch-clients.ts
@@ -35,7 +35,7 @@ build.on("close", (code: number | null) => {
 
         const customEnv: NodeJS.ProcessEnv = {
             ...process.env,
-            NODE_ENV: "production",
+            NODE_ENV: "development",
             NODE_OPTIONS: "--enable-source-maps",
             BAR_STATE_PATH: statePath,
             BAR_ASSETS_PATH: assetsPath,


### PR DESCRIPTION
Now that we have proper use of the Single Instance Lock, we were prevented launching multiple clients for development testing. This fixes the lock, script, and test to permit launching multiple instances while `NODE_ENV` is equal to `development`.