### PR TITLE
Give the main process one owner for session state

### DIFF
--- a/lang/dev/lobby.json
+++ b/lang/dev/lobby.json
@@ -267,7 +267,22 @@
                 "playersOnline": "Plyreas Oinnle",
                 "error": "Eorrr",
                 "reconnecting": "Recotnnenicg...",
-                "offline": "Oniflfe"
+                "offline": "Oniflfe",
+                "changeStatus": "Canghe Satuts",
+                "statusOnline": "Oinnle",
+                "statusBusy": "Busy",
+                "statusBusyUnavailable": "The sveerr has no way to show tihs yet",
+                "goOffline": "Go Oniflfe",
+                "cancel": "Ceancl",
+                "connect": "Cnnocet",
+                "connectTitle": "Cnnocet to the sveerr?",
+                "connectBody": "You are sgneid in but not cntnoeecd. Cniotcneng bnirgs back paiters, leibbos and mnchaaiktmg.",
+                "disconnect": "Dsnncoicet",
+                "disconnectTitle": "Dsnncoicet form the sveerr?",
+                "disconnectBody": "You wlil laeve any party, lobby or mnchaaiktmg qeuue you are in. You stay sgneid in and can ccnneot agian wehenevr you like.",
+                "stopReconnecting": "Sotp trinyg",
+                "stopReconnectingTitle": "Sotp rionentcnecg?",
+                "stopReconnectingBody": "No fuethrr apmtttes wlil be made uitnl you ccnneot agian yreoulsf."
             },
             "messages": {
                 "message": "Msaesge",

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -230,6 +230,8 @@
             "exit": {
                 "title": "Exit",
                 "login": "Login",
+                "connect": "Connect",
+                "disconnect": "Disconnect",
                 "logout": "Logout",
                 "quitToDesktop": "Quit to Desktop"
             },

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -230,8 +230,6 @@
             "exit": {
                 "title": "Exit",
                 "login": "Login",
-                "connect": "Connect",
-                "disconnect": "Disconnect",
                 "logout": "Logout",
                 "quitToDesktop": "Quit to Desktop"
             },
@@ -270,7 +268,22 @@
                 "playersOnline": "Players Online",
                 "error": "Error",
                 "reconnecting": "Reconnecting...",
-                "offline": "Offline"
+                "offline": "Offline",
+                "changeStatus": "Change Status",
+                "statusOnline": "Online",
+                "statusBusy": "Busy",
+                "statusBusyUnavailable": "The server has no way to show this yet",
+                "goOffline": "Go Offline",
+                "cancel": "Cancel",
+                "connect": "Connect",
+                "connectTitle": "Connect to the server?",
+                "connectBody": "You are signed in but not connected. Connecting brings back parties, lobbies and matchmaking.",
+                "disconnect": "Disconnect",
+                "disconnectTitle": "Disconnect from the server?",
+                "disconnectBody": "You will leave any party, lobby or matchmaking queue you are in. You stay signed in and can connect again whenever you like.",
+                "stopReconnecting": "Stop trying",
+                "stopReconnectingTitle": "Stop reconnecting?",
+                "stopReconnectingBody": "No further attempts will be made until you connect again yourself."
             },
             "messages": {
                 "message": "Message",

--- a/src/main/json/file-store.ts
+++ b/src/main/json/file-store.ts
@@ -19,6 +19,8 @@ export class FileStore<T extends TObject> {
     protected readonly ajv: Ajv;
     protected readonly validator: ValidateFunction<Static<T>>;
 
+    private writeQueue: Promise<void> = Promise.resolve();
+
     constructor(filePath: string, schema: T, defaultModel?: Static<T>) {
         this.filePath = filePath;
         this.schema = schema;
@@ -69,7 +71,18 @@ export class FileStore<T extends TObject> {
         }
     }
 
+    // Writes are chained and go through a temp file, so overlapping saves can't
+    // interleave and a crash mid-write can't truncate the existing file.
     protected async write() {
-        await fs.promises.writeFile(this.filePath, JSON.stringify(this.model, null, 4));
+        const write = this.writeQueue.catch(() => {}).then(() => this.writeModel());
+        this.writeQueue = write.catch(() => {});
+
+        return write;
+    }
+
+    private async writeModel() {
+        const tempPath = `${this.filePath}.tmp`;
+        await fs.promises.writeFile(tempPath, JSON.stringify(this.model, null, 4));
+        await fs.promises.rename(tempPath, this.filePath);
     }
 }

--- a/src/main/json/model/account.ts
+++ b/src/main/json/model/account.ts
@@ -7,4 +7,8 @@ import { Type } from "@sinclair/typebox";
 export const accountSchema = Type.Object({
     token: Type.String({ default: "" }),
     refreshToken: Type.String({ default: "" }),
+    // Access tokens are opaque to us, so their lifetime has to be recorded here
+    // rather than read back out of the token.
+    expiresAt: Type.Number({ default: 0 }),
+    encrypted: Type.Boolean({ default: false }),
 });

--- a/src/main/json/model/account.ts
+++ b/src/main/json/model/account.ts
@@ -13,4 +13,15 @@ export const accountSchema = Type.Object({
     // Deliberately has no default: absent means the file predates this field and
     // we have to work out for ourselves whether the values are encrypted.
     encrypted: Type.Optional(Type.Boolean()),
+    // Who the stored credentials belong to. Kept beside them so the two can't
+    // drift apart, and so the name is available before any socket exists. Only
+    // the server can tell us this, so it lands here when user/self arrives.
+    identity: Type.Optional(
+        Type.Object({
+            userId: Type.String(),
+            username: Type.String(),
+            displayName: Type.String(),
+            countryCode: Type.String({ default: "" }),
+        })
+    ),
 });

--- a/src/main/json/model/account.ts
+++ b/src/main/json/model/account.ts
@@ -10,5 +10,7 @@ export const accountSchema = Type.Object({
     // Access tokens are opaque to us, so their lifetime has to be recorded here
     // rather than read back out of the token.
     expiresAt: Type.Number({ default: 0 }),
-    encrypted: Type.Boolean({ default: false }),
+    // Deliberately has no default: absent means the file predates this field and
+    // we have to work out for ourselves whether the values are encrypted.
+    encrypted: Type.Optional(Type.Boolean()),
 });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -138,7 +138,7 @@ app.whenReady().then(async () => {
     logService.registerIpcHandlers();
     infoService.registerIpcHandlers();
     settingsService.registerIpcHandlers();
-    authService.registerIpcHandlers();
+    authService.registerIpcHandlers(webContents);
     tachyonService.registerIpcHandlers(webContents);
     replaysService.registerIpcHandlers(webContents);
     engineService.registerIpcHandlers();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,7 +12,6 @@ import netFromNode from "node:net";
 import { createWindow } from "@main/main-window";
 import { settingsService } from "./services/settings.service";
 import { infoService } from "./services/info.service";
-import { accountService } from "./services/account.service";
 import { logService } from "@main/services/log.service";
 import engineService from "./services/engine.service";
 import mapsService from "./services/maps.service";
@@ -130,7 +129,7 @@ app.whenReady().then(async () => {
         setAssetsPath(savedAssetsPath);
     }
     await engineService.init();
-    await Promise.all([accountService.init(), replaysService.init(), gameService.init(), mapsService.init(), autoUpdaterService.init()]);
+    await Promise.all([authService.init(), replaysService.init(), gameService.init(), mapsService.init(), autoUpdaterService.init()]);
 
     const mainWindow = createWindow();
     const webContents = typedWebContents(mainWindow.webContents);

--- a/src/main/model/user.ts
+++ b/src/main/model/user.ts
@@ -2,6 +2,17 @@
 //
 // SPDX-License-Identifier: MIT
 
+// What is kept beside the credentials so the signed in account has a name before
+// anything has connected. Deliberately not derived from User: it is a stored
+// shape, and following changes to the live model would silently reinterpret what
+// is already on disk.
+export interface StoredIdentity {
+    userId: string;
+    username: string;
+    displayName: string;
+    countryCode: string;
+}
+
 export type User = {
     userId: string;
     username: string;

--- a/src/main/oauth2/oauth2.ts
+++ b/src/main/oauth2/oauth2.ts
@@ -5,17 +5,57 @@
 import { OAUTH_CLIENT_ID, OAUTH_SCOPE, getOAuthAuthorizationServerURL, getOAuthWellKnownURL } from "@main/config/server";
 import { generatePKCE } from "@main/oauth2/pkce";
 import RedirectHandler from "@main/oauth2/redirect-handler";
-import { accountService } from "@main/services/account.service";
 import { logger } from "@main/utils/logger";
 import { shell } from "electron";
-import { stringify } from "node:querystring";
 
-const log = logger("oauth2-utils");
+const log = logger("oauth2");
 
-interface TokenResponse {
+export interface TokenResponse {
     token: string;
     refreshToken: string;
     expiresIn: number;
+}
+
+// Carries enough detail for the session owner to decide between retrying and
+// dropping the stored credentials. Everything here is safe to log.
+export type TokenErrorKind = "network" | "server" | "invalid_grant" | "protocol";
+
+export class TokenRequestError extends Error {
+    readonly kind: TokenErrorKind;
+
+    constructor(kind: TokenErrorKind, message: string) {
+        super(message);
+        this.name = "TokenRequestError";
+        this.kind = kind;
+    }
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function isOnAuthorizationServer(url: string): boolean {
+    try {
+        return new URL(url).origin === getOAuthAuthorizationServerURL();
+    } catch {
+        return false;
+    }
+}
+
+async function request(url: string, init?: RequestInit): Promise<Response> {
+    try {
+        return await fetch(url, init);
+    } catch (error) {
+        throw new TokenRequestError("network", `Could not reach ${url}: ${describeError(error)}`);
+    }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+    try {
+        return await response.json();
+    } catch {
+        throw new TokenRequestError("protocol", "Response body is not valid JSON");
+    }
 }
 
 //TODO cache this response according to HTTP cache headers returned from server
@@ -23,24 +63,26 @@ export async function fetchAuthorizationServerMetadata(): Promise<{
     authorizationEndpoint: string;
     tokenEndpoint: string;
 }> {
-    const response = await fetch(getOAuthWellKnownURL());
-    if (response.status !== 200) {
-        const error = `Failed to fetch OAuth2 authorization server metadata: ${response.status} ${response.statusText}`;
-        log.error(error);
-        throw new Error(error);
+    const response = await request(getOAuthWellKnownURL());
+    if (!response.ok) {
+        throw new TokenRequestError(response.status >= 500 ? "server" : "protocol", `Failed to fetch OAuth2 authorization server metadata: ${response.status} ${response.statusText}`);
     }
-    const body = await response.json();
+
+    const body = (await readJson(response)) as Record<string, unknown>;
     const { authorization_endpoint, token_endpoint, issuer } = body;
-    if (!authorization_endpoint || !token_endpoint || !issuer) {
-        const error = "Invalid OAuth2 authorization server metadata";
-        log.error(`${error}: ${JSON.stringify(body)}`);
-        throw new Error(error);
+
+    if (typeof authorization_endpoint !== "string" || typeof token_endpoint !== "string" || typeof issuer !== "string") {
+        throw new TokenRequestError("protocol", `Invalid OAuth2 authorization server metadata: ${JSON.stringify(body)}`);
     }
 
     if (issuer !== getOAuthAuthorizationServerURL()) {
-        const error = `Invalid OAuth2 issuer: ${issuer} does not match expected ${getOAuthAuthorizationServerURL()}`;
-        log.error(error);
-        throw new Error(error);
+        throw new TokenRequestError("protocol", `Invalid OAuth2 issuer: ${issuer} does not match expected ${getOAuthAuthorizationServerURL()}`);
+    }
+
+    // The metadata document decides where we send the user and where we post
+    // secrets, so neither endpoint may point off the authorization server.
+    if (!isOnAuthorizationServer(authorization_endpoint) || !isOnAuthorizationServer(token_endpoint)) {
+        throw new TokenRequestError("protocol", "OAuth2 endpoints do not belong to the authorization server");
     }
 
     return {
@@ -52,138 +94,132 @@ export async function fetchAuthorizationServerMetadata(): Promise<{
 // Careful with shell.openExternal. https://benjamin-altpeter.de/shell-openexternal-dangers/
 function openInBrowser(url: string) {
     if (!["https:", "http:"].includes(new URL(url).protocol)) return;
-    // Additional checks to prevent opening arbitrary URLs
-    if (!url.startsWith(getOAuthAuthorizationServerURL())) return;
+    if (!isOnAuthorizationServer(url)) return;
     shell.openExternal(url);
 }
 
-function createUrlWithQuerystring(baseUrl: string, params: Record<string, string | number | boolean>): string {
-    const queryString = stringify(params);
-    return `${baseUrl}?${queryString}`;
+async function requestToken(tokenEndpoint: string, params: Record<string, string>): Promise<unknown> {
+    // RFC 6749 4.1.3: these go in a form-encoded body. In the query string they
+    // end up in the server's access logs and in ours.
+    const response = await request(tokenEndpoint, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(params),
+    });
+
+    if (!response.ok) throw await tokenError(response);
+
+    return readJson(response);
+}
+
+async function tokenError(response: Response): Promise<TokenRequestError> {
+    const body = await response.text().catch(() => "");
+    let code: unknown;
+    let description: unknown;
+
+    try {
+        const parsed = JSON.parse(body);
+        code = parsed?.error;
+        description = parsed?.error_description;
+    } catch {
+        // Not every failure comes back as the JSON the spec asks for.
+    }
+
+    const detail = [code, description].filter(Boolean).join(": ") || response.statusText;
+
+    if (response.status >= 500) {
+        return new TokenRequestError("server", `Token endpoint failed (${response.status}): ${detail}`);
+    }
+    if (code === "invalid_grant") {
+        return new TokenRequestError("invalid_grant", `Token rejected: ${detail}`);
+    }
+
+    return new TokenRequestError("protocol", `Token request rejected (${response.status}): ${detail}`);
+}
+
+function parseTokenResponse(body: unknown, currentRefreshToken?: string): TokenResponse {
+    const { access_token, refresh_token, expires_in } = (body ?? {}) as Record<string, unknown>;
+
+    if (typeof access_token !== "string" || !access_token) {
+        throw new TokenRequestError("protocol", "Token response has no access_token");
+    }
+
+    if (typeof expires_in !== "number" || !Number.isFinite(expires_in) || expires_in <= 0) {
+        throw new TokenRequestError("protocol", `Token response has an unusable expires_in: ${String(expires_in)}`);
+    }
+
+    const refreshToken = typeof refresh_token === "string" && refresh_token ? refresh_token : currentRefreshToken;
+    if (!refreshToken) {
+        throw new TokenRequestError("protocol", "Token response has no refresh_token");
+    }
+
+    return {
+        token: access_token,
+        refreshToken,
+        expiresIn: expires_in,
+    };
 }
 
 export async function authenticate(): Promise<TokenResponse> {
     const { authorizationEndpoint, tokenEndpoint } = await fetchAuthorizationServerMetadata();
     const [code_verifier, code_challenge] = generatePKCE();
     const redirectHandler = new RedirectHandler();
+
     try {
         const redirect_uri = await redirectHandler.start();
+
         // TODO set state parameter to prevent CSRF attacks
         // https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1
-        const url = createUrlWithQuerystring(authorizationEndpoint, {
+        const authorizationUrl = new URL(authorizationEndpoint);
+        authorizationUrl.search = new URLSearchParams({
             client_id: OAUTH_CLIENT_ID,
             scope: OAUTH_SCOPE,
             response_type: "code",
             redirect_uri,
             code_challenge,
             code_challenge_method: "S256",
-        });
-        openInBrowser(url);
+        }).toString();
+
+        openInBrowser(authorizationUrl.toString());
+
         const callbackUrl = await redirectHandler.waitForCallback();
-        log.debug(`Received callback URL: ${callbackUrl}`);
         const code = callbackUrl.searchParams.get("code");
 
-        if (!code) throw new Error("Call back URL code is not specified");
+        if (!code) {
+            const denied = callbackUrl.searchParams.get("error");
+            throw new TokenRequestError("protocol", denied ? `Authorization failed: ${denied}` : "Callback URL has no authorization code");
+        }
 
-        log.debug(`Received OAuth2 code: ${code}`);
-        const tokenUrl = createUrlWithQuerystring(tokenEndpoint, {
-            grant_type: "authorization_code",
-            client_id: OAUTH_CLIENT_ID,
-            scope: OAUTH_SCOPE,
-            code,
-            code_verifier,
-            redirect_uri,
-        });
-        const tokenResponse = await fetch(tokenUrl, {
-            method: "POST",
-        });
-        if (tokenResponse.status !== 200) {
-            const responseText = await tokenResponse.text();
-            const error = `Failed to fetch OAuth2 token: ${tokenResponse.status} ${tokenResponse.statusText} ${responseText}`;
-            log.error(error);
-            throw new Error(error);
-        }
-        // Refresh token is mandatory for this app to work
-        const body = await tokenResponse.json();
-        const { access_token, refresh_token, expires_in } = body;
-        if (!access_token || !refresh_token) {
-            const error = "Invalid OAuth2 token response";
-            log.error(`${error}: ${JSON.stringify(body)}`);
-            throw new Error(error);
-        }
-        return {
-            token: access_token,
-            refreshToken: refresh_token,
-            expiresIn: expires_in,
-        };
-    } catch (error) {
-        log.error("Error during login");
-        throw error;
+        log.debug("Exchanging authorization code for tokens");
+
+        return parseTokenResponse(
+            await requestToken(tokenEndpoint, {
+                grant_type: "authorization_code",
+                client_id: OAUTH_CLIENT_ID,
+                scope: OAUTH_SCOPE,
+                code,
+                code_verifier,
+                redirect_uri,
+            })
+        );
     } finally {
         redirectHandler.close();
     }
 }
 
-export async function renewAccessToken(): Promise<TokenResponse> {
-    log.debug("Renewing access token");
+export async function renewAccessToken(refreshToken: string): Promise<TokenResponse> {
     const { tokenEndpoint } = await fetchAuthorizationServerMetadata();
-    const refreshToken = await accountService.getRefreshToken();
-    if (!refreshToken) {
-        const error = "No refresh token available";
-        log.error(error);
-        stopTokenRenewer();
-        throw new Error(error);
-    }
-    const tokenUrl = createUrlWithQuerystring(tokenEndpoint, {
-        grant_type: "refresh_token",
-        client_id: OAUTH_CLIENT_ID,
-        scope: OAUTH_SCOPE,
-        refresh_token: refreshToken,
-    });
-    const tokenResponse = await fetch(tokenUrl, {
-        method: "POST",
-    });
-    if (tokenResponse.status !== 200) {
-        const error = `Failed to renew token, wiping: ${tokenResponse.status} ${tokenResponse.statusText}`;
-        const responseText = await tokenResponse.text();
-        log.error(`${error}: ${responseText}`);
-        accountService.wipe();
-        if (tokenResponse.status === 400) {
-            log.error(`400 Bad request: ${tokenUrl}`);
-        }
-        throw new Error(error);
-    }
-    const body = await tokenResponse.json();
-    const { access_token, refresh_token, expires_in } = body;
-    if (!access_token || !expires_in) {
-        const error = "Invalid OAuth2 token response";
-        log.error(`${error}: ${JSON.stringify(body)}`);
-        throw new Error(error);
-    }
-    if (!refresh_token) {
-        log.info("No new refresh token in token response, keeping the current one.");
-    }
-    log.debug("Renewed access token");
-    return {
-        token: access_token,
-        refreshToken: refresh_token ? refresh_token : refreshToken,
-        expiresIn: expires_in,
-    };
-}
 
-let tokenRenewer;
-export function startTokenRenewer(interval: number) {
-    stopTokenRenewer();
-    tokenRenewer = setInterval(() => {
-        renewAccessToken().then((value) => {
-            accountService.saveRefreshToken(value.refreshToken);
-            accountService.saveToken(value.token);
-            log.info("Saved new tokens.");
-        });
-    }, interval);
-}
+    log.debug("Renewing access token");
 
-export function stopTokenRenewer() {
-    if (!tokenRenewer) return;
-    clearInterval(tokenRenewer);
+    // A server is allowed to keep the current refresh token rather than rotate it.
+    return parseTokenResponse(
+        await requestToken(tokenEndpoint, {
+            grant_type: "refresh_token",
+            client_id: OAUTH_CLIENT_ID,
+            scope: OAUTH_SCOPE,
+            refresh_token: refreshToken,
+        }),
+        refreshToken
+    );
 }

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -13,57 +13,70 @@ const log = logger("account-service");
 
 const accountStore = new FileStore<typeof accountSchema>(path.join(CONFIG_PATH, "account.json"), accountSchema);
 
+export interface StoredTokens {
+    token: string;
+    refreshToken: string;
+    expiresAt: number;
+}
+
 async function init() {
     await accountStore.init();
 }
 
-async function saveToken(token: string) {
-    if (safeStorage.isEncryptionAvailable()) {
-        token = safeStorage.encryptString(token).toString("base64");
-    } else {
-        log.warn("Encryption is not available, storing token in plain text");
+// Whether the values on disk are encrypted is recorded alongside them, because
+// safeStorage can stop being available between one run and the next.
+function readStoredValue(value: string, label: string): string {
+    if (!value) return "";
+
+    if (!accountStore.model.encrypted) return value;
+
+    if (!safeStorage.isEncryptionAvailable()) {
+        log.error(`Cannot read stored ${label}, encryption is no longer available`);
+        return "";
     }
-    await accountStore.update({ token });
+
+    try {
+        return safeStorage.decryptString(Buffer.from(value, "base64"));
+    } catch (e) {
+        log.error(`Failed to decrypt stored ${label}`, e);
+        return "";
+    }
 }
 
-async function saveRefreshToken(refreshToken: string) {
-    if (safeStorage.isEncryptionAvailable()) {
-        refreshToken = safeStorage.encryptString(refreshToken).toString("base64");
-    } else {
-        log.warn("Encryption is not available, storing refreshToken in plain text");
+// The server drops the old refresh token as soon as a renewal succeeds, so the
+// pair is written in a single update. Half-applied state locks the user out.
+async function saveTokens({ token, refreshToken, expiresAt }: StoredTokens) {
+    const encrypted = safeStorage.isEncryptionAvailable();
+    if (!encrypted) {
+        log.warn("Encryption is not available, storing tokens in plain text");
     }
-    await accountStore.update({ refreshToken });
+
+    const encode = (value: string) => (encrypted ? safeStorage.encryptString(value).toString("base64") : value);
+
+    await accountStore.update({
+        token: encode(token),
+        refreshToken: encode(refreshToken),
+        expiresAt,
+        encrypted,
+    });
 }
 
-async function getToken() {
-    const { token } = await accountStore.model;
-    if (safeStorage.isEncryptionAvailable() && token) {
-        try {
-            return safeStorage.decryptString(Buffer.from(token, "base64"));
-        } catch (e) {
-            log.error("Failed to decrypt token, wiping account data", e);
-            await wipe();
-        }
-    }
-    return token;
+function getToken(): string {
+    return readStoredValue(accountStore.model.token, "token");
 }
 
-async function getRefreshToken() {
-    const { refreshToken } = await accountStore.model;
-    if (safeStorage.isEncryptionAvailable() && refreshToken) {
-        try {
-            return safeStorage.decryptString(Buffer.from(refreshToken, "base64"));
-        } catch (e) {
-            log.error("Failed to decrypt refreshToken, wiping account data", e);
-            await wipe();
-        }
-    }
-    return refreshToken;
+function getRefreshToken(): string {
+    return readStoredValue(accountStore.model.refreshToken, "refresh token");
+}
+
+function getExpiresAt(): number {
+    return accountStore.model.expiresAt;
 }
 
 async function forgetToken() {
     await accountStore.update({
         token: "",
+        expiresAt: 0,
     });
 }
 
@@ -71,16 +84,17 @@ async function wipe() {
     await accountStore.update({
         token: "",
         refreshToken: "",
+        expiresAt: 0,
     });
 }
 
 export type Account = typeof accountStore.model;
 export const accountService = {
     init,
-    saveToken,
-    saveRefreshToken,
+    saveTokens,
     getToken,
     getRefreshToken,
+    getExpiresAt,
     wipe,
     forgetToken,
 };

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -19,6 +19,13 @@ export interface StoredTokens {
     expiresAt: number;
 }
 
+export interface StoredIdentity {
+    userId: string;
+    username: string;
+    displayName: string;
+    countryCode: string;
+}
+
 async function init() {
     await accountStore.init();
 }
@@ -79,11 +86,22 @@ function getExpiresAt(): number {
     return accountStore.model.expiresAt;
 }
 
+async function saveIdentity(identity: StoredIdentity) {
+    await accountStore.update({ identity });
+}
+
+function getIdentity(): StoredIdentity | undefined {
+    return accountStore.model.identity;
+}
+
+// Signing out takes the identity with the credentials, so the next sign in
+// doesn't start by showing whoever used the client last.
 async function wipe() {
     await accountStore.update({
         token: "",
         refreshToken: "",
         expiresAt: 0,
+        identity: undefined,
     });
 }
 
@@ -94,5 +112,7 @@ export const accountService = {
     getToken,
     getRefreshToken,
     getExpiresAt,
+    saveIdentity,
+    getIdentity,
     wipe,
 };

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -79,13 +79,6 @@ function getExpiresAt(): number {
     return accountStore.model.expiresAt;
 }
 
-async function forgetToken() {
-    await accountStore.update({
-        token: "",
-        expiresAt: 0,
-    });
-}
-
 async function wipe() {
     await accountStore.update({
         token: "",
@@ -102,5 +95,4 @@ export const accountService = {
     getRefreshToken,
     getExpiresAt,
     wipe,
-    forgetToken,
 };

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -28,16 +28,22 @@ async function init() {
 function readStoredValue(value: string, label: string): string {
     if (!value) return "";
 
-    if (!accountStore.model.encrypted) return value;
+    const { encrypted } = accountStore.model;
+
+    if (encrypted === false) return value;
 
     if (!safeStorage.isEncryptionAvailable()) {
-        log.error(`Cannot read stored ${label}, encryption is no longer available`);
+        log.error(`Cannot read stored ${label}, encryption is not available`);
         return "";
     }
 
     try {
         return safeStorage.decryptString(Buffer.from(value, "base64"));
     } catch (e) {
+        // A file written before the flag existed may hold a plain value, from a
+        // run where encryption wasn't available.
+        if (encrypted === undefined) return value;
+
         log.error(`Failed to decrypt stored ${label}`, e);
         return "";
     }

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -8,6 +8,7 @@ import { accountSchema } from "@main/json/model/account";
 import { logger } from "@main/utils/logger";
 import { safeStorage } from "electron";
 import path from "path";
+import type { StoredIdentity } from "@main/model/user";
 
 const log = logger("account-service");
 
@@ -17,13 +18,6 @@ export interface StoredTokens {
     token: string;
     refreshToken: string;
     expiresAt: number;
-}
-
-export interface StoredIdentity {
-    userId: string;
-    username: string;
-    displayName: string;
-    countryCode: string;
 }
 
 async function init() {

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -184,6 +184,7 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     ipcMain.handle("auth:logout", () => signOut());
     ipcMain.handle("auth:hasCredentials", () => !!accountService.getRefreshToken());
     ipcMain.handle("auth:state", () => state());
+    ipcMain.handle("auth:identity", () => accountService.getIdentity());
 }
 
 export const authService = {

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { authenticate, renewAccessToken, TokenRequestError, TokenResponse } from "@main/oauth2/oauth2";
+import type { StoredIdentity } from "@main/model/user";
 import { accountService } from "@main/services/account.service";
 import { logger } from "@main/utils/logger";
 import { ipcMain, type BarIpcWebContents } from "@main/typed-ipc";
@@ -177,6 +178,22 @@ function state(): AuthState {
     return { authenticated };
 }
 
+// Identity arrives over the socket rather than from the token exchange, so it
+// reaches us separately from everything else the session holds. Failing to store
+// it costs the name shown before the next connection and nothing more, so it is
+// not worth handing back to whoever passed it in.
+async function setIdentity(identity: StoredIdentity) {
+    try {
+        await accountService.saveIdentity(identity);
+    } catch (error) {
+        log.error(`Could not store the account identity: ${describeError(error)}`);
+    }
+}
+
+async function init() {
+    await accountService.init();
+}
+
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     emit = (next: AuthState) => webContents.send("auth:changed", next);
 
@@ -188,6 +205,8 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 }
 
 export const authService = {
+    init,
     registerIpcHandlers,
     getAccessToken,
+    setIdentity,
 };

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { authenticate, renewAccessToken, TokenRequestError, TokenResponse } from "@main/oauth2/oauth2";
+import { Signal } from "$/jaz-ts-utils/signal";
 import type { StoredIdentity } from "@main/model/user";
 import { accountService } from "@main/services/account.service";
 import { logger } from "@main/utils/logger";
@@ -23,7 +24,11 @@ const TRANSIENT_RETRY_MS = 60 * 1000;
 let renewalTimer: NodeJS.Timeout | undefined;
 let renewalInFlight: Promise<void> | undefined;
 let authenticated = false;
-let emit: ((state: AuthState) => void) | undefined;
+
+// Raised whenever the session starts or ends. Kept apart from the IPC wiring so
+// that telling the renderer is one subscriber rather than the only way anything
+// hears about it.
+const onChanged = new Signal<AuthState>();
 
 function describeError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
@@ -37,7 +42,7 @@ function setAuthenticated(next: boolean, reason?: AuthLossReason) {
     if (authenticated === next) return;
 
     authenticated = next;
-    emit?.({ authenticated, reason });
+    onChanged.dispatch({ authenticated, reason });
 }
 
 function stopRenewal() {
@@ -195,7 +200,7 @@ async function init() {
 }
 
 function registerIpcHandlers(webContents: BarIpcWebContents) {
-    emit = (next: AuthState) => webContents.send("auth:changed", next);
+    onChanged.add((next) => webContents.send("auth:changed", next));
 
     ipcMain.handle("auth:login", (_event, interactive) => signIn(interactive ?? true));
     ipcMain.handle("auth:logout", () => signOut());
@@ -209,4 +214,5 @@ export const authService = {
     registerIpcHandlers,
     getAccessToken,
     setIdentity,
+    onChanged,
 };

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -2,41 +2,195 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { authenticate, renewAccessToken, startTokenRenewer, stopTokenRenewer } from "@main/oauth2/oauth2";
+import { authenticate, renewAccessToken, TokenRequestError, TokenResponse } from "@main/oauth2/oauth2";
 import { accountService } from "@main/services/account.service";
 import { logger } from "@main/utils/logger";
-import { ipcMain } from "@main/typed-ipc";
+import { ipcMain, type BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("auth-service");
 
-function registerIpcHandlers() {
-    ipcMain.handle("auth:login", async () => {
-        try {
-            const existingRefreshToken = await accountService.getRefreshToken();
-            const { token, refreshToken, expiresIn } = existingRefreshToken ? await renewAccessToken() : await authenticate();
-            await accountService.saveToken(token);
-            await accountService.saveRefreshToken(refreshToken);
-            startTokenRenewer((expiresIn / 2) * 1000);
-        } catch (error) {
-            log.error("Error during login");
-            accountService.wipe();
-            throw error;
-        }
+export type AuthLossReason = "signed-out" | "expired" | "error";
+
+export interface AuthState {
+    authenticated: boolean;
+    reason?: AuthLossReason;
+}
+
+const RENEW_AT_FRACTION_OF_LIFETIME = 0.5;
+const TRANSIENT_RETRY_MS = 60 * 1000;
+
+let renewalTimer: NodeJS.Timeout | undefined;
+let renewalInFlight: Promise<void> | undefined;
+let authenticated = false;
+let emit: ((state: AuthState) => void) | undefined;
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function kindOf(error: unknown): TokenRequestError["kind"] {
+    return error instanceof TokenRequestError ? error.kind : "protocol";
+}
+
+function setAuthenticated(next: boolean, reason?: AuthLossReason) {
+    if (authenticated === next) return;
+
+    authenticated = next;
+    emit?.({ authenticated, reason });
+}
+
+function stopRenewal() {
+    if (!renewalTimer) return;
+
+    clearTimeout(renewalTimer);
+    renewalTimer = undefined;
+}
+
+function scheduleRenewal(delayMs: number) {
+    stopRenewal();
+    renewalTimer = setTimeout(() => void renew(), delayMs);
+}
+
+async function storeTokens({ token, refreshToken, expiresIn }: TokenResponse) {
+    await accountService.saveTokens({
+        token,
+        refreshToken,
+        expiresAt: Date.now() + expiresIn * 1000,
     });
-    ipcMain.handle("auth:logout", async () => {
-        stopTokenRenewer();
-        await accountService.forgetToken();
+
+    scheduleRenewal(expiresIn * 1000 * RENEW_AT_FRACTION_OF_LIFETIME);
+}
+
+async function renew(): Promise<void> {
+    if (renewalInFlight) return renewalInFlight;
+
+    renewalInFlight = renewOnce().finally(() => {
+        renewalInFlight = undefined;
     });
-    ipcMain.handle("auth:wipe", async () => {
-        stopTokenRenewer();
+
+    return renewalInFlight;
+}
+
+async function renewOnce(): Promise<void> {
+    const refreshToken = accountService.getRefreshToken();
+    if (!refreshToken) {
+        stopRenewal();
+        setAuthenticated(false, "expired");
+        return;
+    }
+
+    try {
+        await storeTokens(await renewAccessToken(refreshToken));
+        setAuthenticated(true);
+        log.info("Renewed access token");
+    } catch (error) {
+        await onRenewalFailed(error);
+    }
+}
+
+async function onRenewalFailed(error: unknown) {
+    const kind = kindOf(error);
+    log.error(`Token renewal failed (${kind}): ${describeError(error)}`);
+
+    if (kind === "invalid_grant") {
+        stopRenewal();
         await accountService.wipe();
-    });
-    ipcMain.handle("auth:hasCredentials", async () => {
-        const refreshToken = await accountService.getRefreshToken();
-        return !!refreshToken;
-    });
+        setAuthenticated(false, "expired");
+        return;
+    }
+
+    // Renewal runs at half the token's lifetime, so there is usually still a
+    // working access token. Keep the session and retry until it really expires.
+    if (accountService.getExpiresAt() > Date.now()) {
+        scheduleRenewal(TRANSIENT_RETRY_MS);
+        return;
+    }
+
+    stopRenewal();
+    setAuthenticated(false, "error");
+}
+
+async function acquireTokens(interactive: boolean): Promise<TokenResponse> {
+    const refreshToken = accountService.getRefreshToken();
+    if (!refreshToken) {
+        if (!interactive) throw new TokenRequestError("invalid_grant", "No stored credentials");
+
+        return authenticate();
+    }
+
+    try {
+        return await renewAccessToken(refreshToken);
+    } catch (error) {
+        if (kindOf(error) !== "invalid_grant") throw error;
+
+        await accountService.wipe();
+        if (!interactive) throw error;
+
+        // Without this, the first sign in after the server drops our refresh
+        // token always fails and the user has to click again.
+        log.info("Stored refresh token was rejected, falling back to interactive sign in");
+
+        return authenticate();
+    }
+}
+
+async function signIn(interactive: boolean) {
+    try {
+        await storeTokens(await acquireTokens(interactive));
+        setAuthenticated(true);
+        log.info("Signed in");
+    } catch (error) {
+        const kind = kindOf(error);
+        log.error(`Sign in failed (${kind}): ${describeError(error)}`);
+
+        stopRenewal();
+        setAuthenticated(false, kind === "invalid_grant" ? "expired" : "error");
+
+        throw error;
+    }
+}
+
+async function signOut() {
+    stopRenewal();
+    await accountService.forgetToken();
+    setAuthenticated(false, "signed-out");
+}
+
+async function forgetAccount() {
+    stopRenewal();
+    await accountService.wipe();
+    setAuthenticated(false, "signed-out");
+}
+
+// Callers get a token that is good right now, or an empty string. Timers don't
+// fire while the machine is asleep, so a scheduled renewal is not a guarantee.
+async function getAccessToken(): Promise<string> {
+    if (hasUsableToken()) return accountService.getToken();
+
+    await renew();
+
+    return hasUsableToken() ? accountService.getToken() : "";
+}
+
+function hasUsableToken(): boolean {
+    return !!accountService.getToken() && accountService.getExpiresAt() > Date.now();
+}
+
+function state(): AuthState {
+    return { authenticated };
+}
+
+function registerIpcHandlers(webContents: BarIpcWebContents) {
+    emit = (next: AuthState) => webContents.send("auth:changed", next);
+
+    ipcMain.handle("auth:login", (_event, interactive) => signIn(interactive ?? true));
+    ipcMain.handle("auth:logout", () => signOut());
+    ipcMain.handle("auth:wipe", () => forgetAccount());
+    ipcMain.handle("auth:hasCredentials", () => !!accountService.getRefreshToken());
+    ipcMain.handle("auth:state", () => state());
 }
 
 export const authService = {
     registerIpcHandlers,
+    getAccessToken,
 };

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -150,13 +150,10 @@ async function signIn(interactive: boolean) {
     }
 }
 
+// Signing out destroys the stored credentials outright. Keeping the refresh
+// token behind the user's back is what made a separate "change account" action
+// necessary, and whether to sign in on launch is a setting of its own.
 async function signOut() {
-    stopRenewal();
-    await accountService.forgetToken();
-    setAuthenticated(false, "signed-out");
-}
-
-async function forgetAccount() {
     stopRenewal();
     await accountService.wipe();
     setAuthenticated(false, "signed-out");
@@ -185,7 +182,6 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 
     ipcMain.handle("auth:login", (_event, interactive) => signIn(interactive ?? true));
     ipcMain.handle("auth:logout", () => signOut());
-    ipcMain.handle("auth:wipe", () => forgetAccount());
     ipcMain.handle("auth:hasCredentials", () => !!accountService.getRefreshToken());
     ipcMain.handle("auth:state", () => state());
 }

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { accountService } from "@main/services/account.service";
 import { authService } from "@main/services/auth.service";
 import { createTachyonRequestHandlers } from "@main/tachyon/tachyon.handlers";
 import { TachyonClient } from "@main/tachyon/tachyon-client";
@@ -21,9 +20,7 @@ function rememberIdentity(event: TachyonEvent) {
 
     try {
         const { userId, username, displayName, countryCode } = event.data.user;
-        accountService.saveIdentity({ userId, username, displayName, countryCode: countryCode ?? "" }).catch((error) => {
-            log.error("Could not store the account identity", error);
-        });
+        void authService.setIdentity({ userId, username, displayName, countryCode: countryCode ?? "" });
     } catch (error) {
         log.error("Could not read the identity out of user/self", error);
     }

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -2,14 +2,26 @@
 //
 // SPDX-License-Identifier: MIT
 
+import { accountService } from "@main/services/account.service";
 import { authService } from "@main/services/auth.service";
 import { createTachyonRequestHandlers } from "@main/tachyon/tachyon.handlers";
 import { TachyonClient } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
+import { TachyonEvent } from "tachyon-protocol";
 import { BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("tachyon-service");
+
+// user/self is the only thing that tells us who we are, and it only ever arrives
+// over the socket. Keeping it beside the credentials means the name is there on
+// the next launch, before anything has connected.
+function rememberIdentity(event: TachyonEvent) {
+    if (event.commandId !== "user/self") return;
+
+    const { userId, username, displayName, countryCode } = event.data.user;
+    accountService.saveIdentity({ userId, username, displayName, countryCode: countryCode ?? "" });
+}
 
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     const requestHandlers = createTachyonRequestHandlers(webContents);
@@ -27,6 +39,7 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 
     tachyonClient.onEvent.add((event) => {
         log.info(`Received event: ${JSON.stringify(event)}`);
+        rememberIdentity(event);
         webContents.send("tachyon:event", event);
     });
 

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -19,8 +19,14 @@ const log = logger("tachyon-service");
 function rememberIdentity(event: TachyonEvent) {
     if (event.commandId !== "user/self") return;
 
-    const { userId, username, displayName, countryCode } = event.data.user;
-    accountService.saveIdentity({ userId, username, displayName, countryCode: countryCode ?? "" });
+    try {
+        const { userId, username, displayName, countryCode } = event.data.user;
+        accountService.saveIdentity({ userId, username, displayName, countryCode: countryCode ?? "" }).catch((error) => {
+            log.error("Could not store the account identity", error);
+        });
+    } catch (error) {
+        log.error("Could not read the identity out of user/self", error);
+    }
 }
 
 function registerIpcHandlers(webContents: BarIpcWebContents) {
@@ -39,8 +45,10 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 
     tachyonClient.onEvent.add((event) => {
         log.info(`Received event: ${JSON.stringify(event)}`);
-        rememberIdentity(event);
+        // Forwarded first, so nothing that goes wrong while storing the identity
+        // can stop the renderer seeing the event.
         webContents.send("tachyon:event", event);
+        rememberIdentity(event);
     });
 
     ipcMain.handle("tachyon:isConnected", () => {

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { accountService } from "@main/services/account.service";
+import { authService } from "@main/services/auth.service";
 import { createTachyonRequestHandlers } from "@main/tachyon/tachyon.handlers";
 import { TachyonClient } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
@@ -36,7 +36,7 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
 
     ipcMain.handle("tachyon:connect", async () => {
         if (!tachyonClient.isConnected()) {
-            const token = await accountService.getToken();
+            const token = await authService.getAccessToken();
             if (!token) {
                 throw new Error("Not authenticated");
             }

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -41,7 +41,8 @@ function createBattleHandlers(webContents: BarIpcWebContents) {
         ...defineTachyonRequestHandler(
             "battle/start",
             createTypedTachyonRequestHandler<"battle/start">()(async (data: BattleStartRequestData) => {
-                log.info(`Received battle start request: ${JSON.stringify(data)}`);
+                // data carries the join password, so it is summarised rather than dumped.
+                log.info(`Received battle start request for ${data.ip}:${data.port}`);
                 const itemsRequired =
                     !gameContentAPI.isVersionInstalled(data.game.springName) || !mapContentAPI.isVersionInstalled(data.map.springName) || !engineContentAPI.isVersionInstalled(data.engine.version);
                 if (itemsRequired) {

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { AuthState } from "@main/services/auth.service";
-import type { StoredIdentity } from "@main/services/account.service";
+import type { StoredIdentity } from "@main/model/user";
 import type { BattleWithMetadata } from "@main/game/battle/battle-types";
 import type { BattleStartRequestData } from "tachyon-protocol/types";
 import type { DownloadInfo } from "@main/content/downloads";

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -66,7 +66,6 @@ export type IPCCommands = {
     "auth:login": (interactive?: boolean) => void;
     "auth:logout": () => void;
     "auth:state": () => AuthState;
-    "auth:wipe": () => void;
     "autoUpdater:checkForUpdates": () => boolean;
     "autoUpdater:downloadUpdate": () => void;
     "autoUpdater:installUpdates": () => void;

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { AuthState } from "@main/services/auth.service";
+import type { StoredIdentity } from "@main/services/account.service";
 import type { BattleWithMetadata } from "@main/game/battle/battle-types";
 import type { BattleStartRequestData } from "tachyon-protocol/types";
 import type { DownloadInfo } from "@main/content/downloads";
@@ -63,6 +64,7 @@ export type IPCEvents = {
 
 export type IPCCommands = {
     "auth:hasCredentials": () => boolean;
+    "auth:identity": () => StoredIdentity | undefined;
     "auth:login": (interactive?: boolean) => void;
     "auth:logout": () => void;
     "auth:state": () => AuthState;

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+import type { AuthState } from "@main/services/auth.service";
 import type { BattleWithMetadata } from "@main/game/battle/battle-types";
 import type { BattleStartRequestData } from "tachyon-protocol/types";
 import type { DownloadInfo } from "@main/content/downloads";
@@ -57,12 +58,14 @@ export type IPCEvents = {
     "tachyon:connected": () => void;
     "tachyon:disconnected": () => void;
     "tachyon:event": (event: TachyonEvent) => void;
+    "auth:changed": (state: AuthState) => void;
 };
 
 export type IPCCommands = {
     "auth:hasCredentials": () => boolean;
-    "auth:login": () => void;
+    "auth:login": (interactive?: boolean) => void;
     "auth:logout": () => void;
+    "auth:state": () => AuthState;
     "auth:wipe": () => void;
     "autoUpdater:checkForUpdates": () => boolean;
     "autoUpdater:downloadUpdate": () => void;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -18,7 +18,7 @@ import type { BattleStartRequestData } from "tachyon-protocol/types";
 import { MultiplayerLaunchSettings } from "@main/game/game";
 import { logLevels } from "@main/services/log.service";
 import { AuthState } from "@main/services/auth.service";
-import { StoredIdentity } from "@main/services/account.service";
+import { StoredIdentity } from "@main/model/user";
 
 const logApi = {
     purge: (): Promise<string[]> => ipcRenderer.invoke("log:purge"),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -18,6 +18,7 @@ import type { BattleStartRequestData } from "tachyon-protocol/types";
 import { MultiplayerLaunchSettings } from "@main/game/game";
 import { logLevels } from "@main/services/log.service";
 import { AuthState } from "@main/services/auth.service";
+import { StoredIdentity } from "@main/services/account.service";
 
 const logApi = {
     purge: (): Promise<string[]> => ipcRenderer.invoke("log:purge"),
@@ -87,6 +88,7 @@ const authApi = {
     logout: (): Promise<void> => ipcRenderer.invoke("auth:logout"),
     hasCredentials: (): Promise<boolean> => ipcRenderer.invoke("auth:hasCredentials"),
     getState: (): Promise<AuthState> => ipcRenderer.invoke("auth:state"),
+    getIdentity: (): Promise<StoredIdentity | undefined> => ipcRenderer.invoke("auth:identity"),
 
     onChanged: (callback: (state: AuthState) => void) => ipcRenderer.on("auth:changed", (_event, state) => callback(state)),
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -85,7 +85,6 @@ contextBridge.exposeInMainWorld("settings", settingsApi);
 const authApi = {
     login: (interactive?: boolean): Promise<void> => ipcRenderer.invoke("auth:login", interactive),
     logout: (): Promise<void> => ipcRenderer.invoke("auth:logout"),
-    wipe: (): Promise<void> => ipcRenderer.invoke("auth:wipe"),
     hasCredentials: (): Promise<boolean> => ipcRenderer.invoke("auth:hasCredentials"),
     getState: (): Promise<AuthState> => ipcRenderer.invoke("auth:state"),
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -17,6 +17,7 @@ import { GetCommandData, GetCommandIds, GetCommands } from "tachyon-protocol";
 import type { BattleStartRequestData } from "tachyon-protocol/types";
 import { MultiplayerLaunchSettings } from "@main/game/game";
 import { logLevels } from "@main/services/log.service";
+import { AuthState } from "@main/services/auth.service";
 
 const logApi = {
     purge: (): Promise<string[]> => ipcRenderer.invoke("log:purge"),
@@ -82,10 +83,13 @@ export type SettingsApi = typeof settingsApi;
 contextBridge.exposeInMainWorld("settings", settingsApi);
 
 const authApi = {
-    login: (): Promise<void> => ipcRenderer.invoke("auth:login"),
+    login: (interactive?: boolean): Promise<void> => ipcRenderer.invoke("auth:login", interactive),
     logout: (): Promise<void> => ipcRenderer.invoke("auth:logout"),
     wipe: (): Promise<void> => ipcRenderer.invoke("auth:wipe"),
     hasCredentials: (): Promise<boolean> => ipcRenderer.invoke("auth:hasCredentials"),
+    getState: (): Promise<AuthState> => ipcRenderer.invoke("auth:state"),
+
+    onChanged: (callback: (state: AuthState) => void) => ipcRenderer.on("auth:changed", (_event, state) => callback(state)),
 };
 export type AuthApi = typeof authApi;
 contextBridge.exposeInMainWorld("auth", authApi);

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -97,7 +97,6 @@ import { battleStore } from "@renderer/store/battle.store";
 import FullscreenGameModeSelector from "@renderer/components/battle/FullscreenGameModeSelector.vue";
 import { useGlobalKeybindings } from "@renderer/composables/useGlobalKeybindings";
 import { me } from "@renderer/store/me.store";
-import { auth } from "@renderer/store/me.store";
 import { useLogInConfirmation } from "@renderer/composables/useLogInConfirmation";
 import { partyStore, PlayersPartyState } from "@renderer/store/party.store";
 import accountGroup from "@iconify-icons/mdi/account-group";
@@ -197,7 +196,6 @@ function onInitialSetupDone() {
 // We do it here and not in index.vue to avoid flashing login page for user before
 // continuing to overview.
 if (!settingsStore.devMode) {
-    auth.playOffline();
     router.push("/play");
 }
 

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2212,8 +2212,6 @@
             "exit": {
                 "title": null,
                 "login": null,
-                "connect": null,
-                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },
@@ -2252,7 +2250,22 @@
                 "playersOnline": null,
                 "error": null,
                 "reconnecting": null,
-                "offline": null
+                "offline": null,
+                "changeStatus": null,
+                "statusOnline": null,
+                "statusBusy": null,
+                "statusBusyUnavailable": null,
+                "goOffline": null,
+                "cancel": null,
+                "connect": null,
+                "connectTitle": null,
+                "connectBody": null,
+                "disconnect": null,
+                "disconnectTitle": null,
+                "disconnectBody": null,
+                "stopReconnecting": null,
+                "stopReconnectingTitle": null,
+                "stopReconnectingBody": null
             },
             "messages": {
                 "message": null,

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2212,6 +2212,8 @@
             "exit": {
                 "title": null,
                 "login": null,
+                "connect": null,
+                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2083,6 +2083,8 @@
             "exit": {
                 "title": null,
                 "login": null,
+                "connect": null,
+                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2083,8 +2083,6 @@
             "exit": {
                 "title": null,
                 "login": null,
-                "connect": null,
-                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },
@@ -2123,7 +2121,22 @@
                 "playersOnline": null,
                 "error": null,
                 "reconnecting": null,
-                "offline": null
+                "offline": null,
+                "changeStatus": null,
+                "statusOnline": null,
+                "statusBusy": null,
+                "statusBusyUnavailable": null,
+                "goOffline": null,
+                "cancel": null,
+                "connect": null,
+                "connectTitle": null,
+                "connectBody": null,
+                "disconnect": null,
+                "disconnectTitle": null,
+                "disconnectBody": null,
+                "stopReconnecting": null,
+                "stopReconnectingTitle": null,
+                "stopReconnectingBody": null
             },
             "messages": {
                 "message": null,

--- a/src/renderer/assets/languages/dev.json
+++ b/src/renderer/assets/languages/dev.json
@@ -267,7 +267,22 @@
                 "playersOnline": "Plyreas Oinnle",
                 "error": "Eorrr",
                 "reconnecting": "Recotnnenicg...",
-                "offline": "Oniflfe"
+                "offline": "Oniflfe",
+                "changeStatus": "Canghe Satuts",
+                "statusOnline": "Oinnle",
+                "statusBusy": "Busy",
+                "statusBusyUnavailable": "The sveerr has no way to show tihs yet",
+                "goOffline": "Go Oniflfe",
+                "cancel": "Ceancl",
+                "connect": "Cnnocet",
+                "connectTitle": "Cnnocet to the sveerr?",
+                "connectBody": "You are sgneid in but not cntnoeecd. Cniotcneng bnirgs back paiters, leibbos and mnchaaiktmg.",
+                "disconnect": "Dsnncoicet",
+                "disconnectTitle": "Dsnncoicet form the sveerr?",
+                "disconnectBody": "You wlil laeve any party, lobby or mnchaaiktmg qeuue you are in. You stay sgneid in and can ccnneot agian wehenevr you like.",
+                "stopReconnecting": "Sotp trinyg",
+                "stopReconnectingTitle": "Sotp rionentcnecg?",
+                "stopReconnectingBody": "No fuethrr apmtttes wlil be made uitnl you ccnneot agian yreoulsf."
             },
             "messages": {
                 "message": "Msaesge",

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2060,8 +2060,6 @@
             "exit": {
                 "title": "Exit",
                 "login": "Login",
-                "connect": "Connect",
-                "disconnect": "Disconnect",
                 "logout": "Logout",
                 "quitToDesktop": "Quit to Desktop"
             },
@@ -2100,7 +2098,22 @@
                 "playersOnline": "Players Online",
                 "error": "Error",
                 "reconnecting": "Reconnecting...",
-                "offline": "Offline"
+                "offline": "Offline",
+                "changeStatus": "Change Status",
+                "statusOnline": "Online",
+                "statusBusy": "Busy",
+                "statusBusyUnavailable": "The server has no way to show this yet",
+                "goOffline": "Go Offline",
+                "cancel": "Cancel",
+                "connect": "Connect",
+                "connectTitle": "Connect to the server?",
+                "connectBody": "You are signed in but not connected. Connecting brings back parties, lobbies and matchmaking.",
+                "disconnect": "Disconnect",
+                "disconnectTitle": "Disconnect from the server?",
+                "disconnectBody": "You will leave any party, lobby or matchmaking queue you are in. You stay signed in and can connect again whenever you like.",
+                "stopReconnecting": "Stop trying",
+                "stopReconnectingTitle": "Stop reconnecting?",
+                "stopReconnectingBody": "No further attempts will be made until you connect again yourself."
             },
             "messages": {
                 "message": "Message",

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2060,6 +2060,8 @@
             "exit": {
                 "title": "Exit",
                 "login": "Login",
+                "connect": "Connect",
+                "disconnect": "Disconnect",
                 "logout": "Logout",
                 "quitToDesktop": "Quit to Desktop"
             },

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4065,6 +4065,8 @@
             "exit": {
                 "title": null,
                 "login": null,
+                "connect": null,
+                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4065,8 +4065,6 @@
             "exit": {
                 "title": null,
                 "login": null,
-                "connect": null,
-                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },
@@ -4105,7 +4103,22 @@
                 "playersOnline": null,
                 "error": null,
                 "reconnecting": null,
-                "offline": null
+                "offline": null,
+                "changeStatus": null,
+                "statusOnline": null,
+                "statusBusy": null,
+                "statusBusyUnavailable": null,
+                "goOffline": null,
+                "cancel": null,
+                "connect": null,
+                "connectTitle": null,
+                "connectBody": null,
+                "disconnect": null,
+                "disconnectTitle": null,
+                "disconnectBody": null,
+                "stopReconnecting": null,
+                "stopReconnectingTitle": null,
+                "stopReconnectingBody": null
             },
             "messages": {
                 "message": null,

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4034,6 +4034,8 @@
             "exit": {
                 "title": null,
                 "login": null,
+                "connect": null,
+                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4034,8 +4034,6 @@
             "exit": {
                 "title": null,
                 "login": null,
-                "connect": null,
-                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },
@@ -4074,7 +4072,22 @@
                 "playersOnline": null,
                 "error": null,
                 "reconnecting": null,
-                "offline": null
+                "offline": null,
+                "changeStatus": null,
+                "statusOnline": null,
+                "statusBusy": null,
+                "statusBusyUnavailable": null,
+                "goOffline": null,
+                "cancel": null,
+                "connect": null,
+                "connectTitle": null,
+                "connectBody": null,
+                "disconnect": null,
+                "disconnectTitle": null,
+                "disconnectBody": null,
+                "stopReconnecting": null,
+                "stopReconnectingTitle": null,
+                "stopReconnectingBody": null
             },
             "messages": {
                 "message": null,

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4176,6 +4176,8 @@
             "exit": {
                 "title": null,
                 "login": null,
+                "connect": null,
+                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4176,8 +4176,6 @@
             "exit": {
                 "title": null,
                 "login": null,
-                "connect": null,
-                "disconnect": null,
                 "logout": null,
                 "quitToDesktop": null
             },
@@ -4216,7 +4214,22 @@
                 "playersOnline": null,
                 "error": null,
                 "reconnecting": null,
-                "offline": null
+                "offline": null,
+                "changeStatus": null,
+                "statusOnline": null,
+                "statusBusy": null,
+                "statusBusyUnavailable": null,
+                "goOffline": null,
+                "cancel": null,
+                "connect": null,
+                "connectTitle": null,
+                "connectBody": null,
+                "disconnect": null,
+                "disconnectTitle": null,
+                "disconnectBody": null,
+                "stopReconnecting": null,
+                "stopReconnectingTitle": null,
+                "stopReconnectingBody": null
             },
             "messages": {
                 "message": null,

--- a/src/renderer/components/navbar/Exit.vue
+++ b/src/renderer/components/navbar/Exit.vue
@@ -10,6 +10,12 @@ SPDX-License-Identifier: MIT
             <Button @click="login" v-if="!me.isAuthenticated && !onLoginPage && settingsStore.devMode">{{
                 t("lobby.navbar.exit.login")
             }}</Button>
+            <Button @click="goOnline" v-if="me.isAuthenticated && !tachyonStore.isConnected && !onLoginPage && settingsStore.devMode">{{
+                t("lobby.navbar.exit.connect")
+            }}</Button>
+            <Button @click="disconnect" v-if="tachyonStore.isConnected && !onLoginPage && settingsStore.devMode">{{
+                t("lobby.navbar.exit.disconnect")
+            }}</Button>
             <Button @click="logout" v-if="me.isAuthenticated && !onLoginPage && settingsStore.devMode">{{
                 t("lobby.navbar.exit.logout")
             }}</Button>
@@ -27,6 +33,7 @@ import Button from "@renderer/components/controls/Button.vue";
 import { auth } from "@renderer/store/me.store";
 import { settingsStore } from "@renderer/store/settings.store";
 import { me } from "@renderer/store/me.store";
+import { tachyon, tachyonStore } from "@renderer/store/tachyon.store";
 import { useTypedI18n } from "@renderer/i18n";
 import { party } from "@renderer/store/party.store";
 const { t } = useTypedI18n();
@@ -42,10 +49,20 @@ async function login() {
     modal.value?.close();
 }
 
+async function goOnline() {
+    await auth.goOnline();
+    modal.value?.close();
+}
+
+async function disconnect() {
+    await tachyon.goOffline();
+    modal.value?.close();
+}
+
+// Signing in on launch is a setting of its own, so signing out leaves it alone.
 async function logout() {
     party.onLogout();
-    auth.logout();
-    settingsStore.loginAutomatically = false;
+    await auth.logout();
     await router.push("/");
     modal.value?.close();
 }

--- a/src/renderer/components/navbar/Exit.vue
+++ b/src/renderer/components/navbar/Exit.vue
@@ -10,12 +10,6 @@ SPDX-License-Identifier: MIT
             <Button @click="login" v-if="!me.isAuthenticated && !onLoginPage && settingsStore.devMode">{{
                 t("lobby.navbar.exit.login")
             }}</Button>
-            <Button @click="goOnline" v-if="me.isAuthenticated && !tachyonStore.isConnected && !onLoginPage && settingsStore.devMode">{{
-                t("lobby.navbar.exit.connect")
-            }}</Button>
-            <Button @click="disconnect" v-if="tachyonStore.isConnected && !onLoginPage && settingsStore.devMode">{{
-                t("lobby.navbar.exit.disconnect")
-            }}</Button>
             <Button @click="logout" v-if="me.isAuthenticated && !onLoginPage && settingsStore.devMode">{{
                 t("lobby.navbar.exit.logout")
             }}</Button>
@@ -33,7 +27,6 @@ import Button from "@renderer/components/controls/Button.vue";
 import { auth } from "@renderer/store/me.store";
 import { settingsStore } from "@renderer/store/settings.store";
 import { me } from "@renderer/store/me.store";
-import { tachyon, tachyonStore } from "@renderer/store/tachyon.store";
 import { useTypedI18n } from "@renderer/i18n";
 import { party } from "@renderer/store/party.store";
 const { t } = useTypedI18n();
@@ -49,22 +42,15 @@ async function login() {
     modal.value?.close();
 }
 
-async function goOnline() {
-    await auth.goOnline();
-    modal.value?.close();
-}
-
-async function disconnect() {
-    await tachyon.goOffline();
-    modal.value?.close();
-}
-
+// Closed up front: signing out flips the buttons this menu is showing, so
+// leaving it open means watching Logout turn into Login before it disappears.
 // Signing in on launch is a setting of its own, so signing out leaves it alone.
 async function logout() {
+    modal.value?.close();
+
     party.onLogout();
     await auth.logout();
     await router.push("/");
-    modal.value?.close();
 }
 
 async function quitToDesktop() {

--- a/src/renderer/components/navbar/ServerStatus.vue
+++ b/src/renderer/components/navbar/ServerStatus.vue
@@ -106,9 +106,11 @@ const pendingAction = computed<ServerAction | undefined>(() => {
 
 const menuOpen = ref(false);
 
-// Which of the menu entries describes where we are right now. Busy is never it,
+// Which of the menu entries describes where we are right now. This follows what
+// the user asked for rather than whether the socket happens to be up, so a drop
+// they did not choose keeps them on Online while we retry. Busy is never it,
 // since the server has no way to represent it.
-const currentStatus = computed(() => (tachyonStore.isConnected ? "online" : "offline"));
+const currentStatus = computed(() => (tachyonStore.wantsConnection ? "online" : "offline"));
 
 const buttonTitle = computed(() => tachyonStore.error ?? t("lobby.navbar.serverStatus.changeStatus"));
 

--- a/src/renderer/components/navbar/ServerStatus.vue
+++ b/src/renderer/components/navbar/ServerStatus.vue
@@ -5,20 +5,54 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <Button @click="handleClick">
-        <div class="flex-row flex-center gap-sm">
-            <div class="server-status-dot" :class="statusClass">⬤</div>
-            <div>{{ statusText }}</div>
+    <div class="status-anchor" v-click-away:serverStatus="() => (menuOpen = false)">
+        <Button :title="buttonTitle" @click="handleClick">
+            <div class="flex-row flex-center gap-sm">
+                <div class="server-status-dot" :class="statusClass">⬤</div>
+                <div>{{ statusText }}</div>
+            </div>
+        </Button>
+
+        <div v-if="menuOpen" class="status-menu flex-col">
+            <Button :class="{ current: currentStatus === 'online' }" @click="chooseOnline">
+                <div class="flex-row flex-center gap-sm">
+                    <div class="server-status-dot online">⬤</div>
+                    <div>{{ t("lobby.navbar.serverStatus.statusOnline") }}</div>
+                </div>
+            </Button>
+            <Button :disabled="true" :title="t('lobby.navbar.serverStatus.statusBusyUnavailable')">
+                <div class="flex-row flex-center gap-sm">
+                    <div class="server-status-dot busy">⬤</div>
+                    <div>{{ t("lobby.navbar.serverStatus.statusBusy") }}</div>
+                </div>
+            </Button>
+            <Button :class="{ current: currentStatus === 'offline' }" @click="chooseOffline">
+                <div class="flex-row flex-center gap-sm">
+                    <div class="server-status-dot offline">⬤</div>
+                    <div>{{ t("lobby.navbar.serverStatus.goOffline") }}</div>
+                </div>
+            </Button>
         </div>
-    </Button>
+    </div>
+
+    <Modal v-if="confirming" v-model="confirmOpen" :title="t(`lobby.navbar.serverStatus.${confirming}Title`)">
+        <div class="confirm flex-col gap-md">
+            <div>{{ t(`lobby.navbar.serverStatus.${confirming}Body`) }}</div>
+            <div class="flex-row gap-md">
+                <Button class="fullwidth" @click="confirming = undefined">{{ t("lobby.navbar.serverStatus.cancel") }}</Button>
+                <Button class="fullwidth red" @click="confirmAction">{{ t(`lobby.navbar.serverStatus.${confirming}`) }}</Button>
+            </div>
+        </div>
+    </Modal>
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import Button from "@renderer/components/controls/Button.vue";
-import { tachyonStore } from "@renderer/store/tachyon.store";
-import { me } from "@renderer/store/me.store";
+import Modal from "@renderer/components/common/Modal.vue";
+import { tachyon, tachyonStore } from "@renderer/store/tachyon.store";
+import { auth, me } from "@renderer/store/me.store";
 import { useTypedI18n } from "@renderer/i18n";
 import { useLogInConfirmation } from "@renderer/composables/useLogInConfirmation";
 
@@ -26,49 +60,138 @@ const { t } = useTypedI18n();
 const router = useRouter();
 const { openLogInConfirmation } = useLogInConfirmation();
 
+type ServerAction = "connect" | "disconnect" | "stopReconnecting";
+
+// Captured when the modal opens rather than read live. The connection can change
+// while the modal sits there, and the user has to get the action they were shown.
+const confirming = ref<ServerAction>();
+
+const confirmOpen = computed({
+    get: () => confirming.value !== undefined,
+    set: (open: boolean) => {
+        if (!open) confirming.value = undefined;
+    },
+});
+
+// Retrying is only knowable from the timer. Deriving it from "not connected"
+// reports attempts that aren't happening, and tachyonStore.error can't stand in
+// for a state either: it is set by the first failed attempt and by server stats
+// requests alike, so it says nothing about whether we are still trying.
+const isReconnecting = computed(() => tachyonStore.reconnectInterval !== undefined);
+
 const statusClass = computed(() => {
     if (!me.isAuthenticated) return "";
     return tachyonStore.isConnected ? "online" : "offline";
 });
 
 const statusText = computed(() => {
-    if (!me.isAuthenticated) {
-        return t("lobby.navbar.serverStatus.offline");
-    }
+    if (!me.isAuthenticated) return t("lobby.navbar.serverStatus.offline");
 
     if (tachyonStore.isConnected) {
         const userCount = tachyonStore.serverStats?.userCount || 0;
         return `${userCount} ${t("lobby.navbar.serverStatus.playersOnline")}`;
     }
 
-    // Retries in flight are the only thing that makes this reconnecting. Being
-    // signed in without a socket is otherwise just offline, and every failed
-    // attempt sets an error, so that has to be the weaker signal of the two.
-    if (tachyonStore.reconnectInterval) {
-        return t("lobby.navbar.serverStatus.reconnecting");
-    }
-
-    if (tachyonStore.error) {
-        return t("lobby.navbar.serverStatus.error");
-    }
+    if (isReconnecting.value) return t("lobby.navbar.serverStatus.reconnecting");
 
     return t("lobby.navbar.serverStatus.offline");
 });
 
+const pendingAction = computed<ServerAction | undefined>(() => {
+    if (!me.isAuthenticated) return undefined;
+    if (tachyonStore.isConnected) return "disconnect";
+
+    return isReconnecting.value ? "stopReconnecting" : "connect";
+});
+
+const menuOpen = ref(false);
+
+// Which of the menu entries describes where we are right now. Busy is never it,
+// since the server has no way to represent it.
+const currentStatus = computed(() => (tachyonStore.isConnected ? "online" : "offline"));
+
+const buttonTitle = computed(() => tachyonStore.error ?? t("lobby.navbar.serverStatus.changeStatus"));
+
 function handleClick() {
     if (!me.isAuthenticated) {
         openLogInConfirmation(router.currentRoute.value);
+        return;
+    }
+
+    menuOpen.value = !menuOpen.value;
+}
+
+function chooseOnline() {
+    menuOpen.value = false;
+    if (tachyonStore.isConnected) return;
+
+    // Reconnecting already leads here, so there is nothing to confirm.
+    void runAction("connect");
+}
+
+// Leaving is disruptive enough that a stray click shouldn't do it, so this one
+// goes through the confirmation rather than acting immediately.
+function chooseOffline() {
+    menuOpen.value = false;
+    confirming.value = pendingAction.value;
+}
+
+function confirmAction() {
+    const action = confirming.value;
+    confirming.value = undefined;
+
+    void runAction(action);
+}
+
+async function runAction(action: ServerAction | undefined) {
+    try {
+        if (action === "connect") await auth.goOnline();
+        if (action === "disconnect" || action === "stopReconnecting") await tachyon.goOffline();
+    } catch (error) {
+        // Surfaced through the status itself; there is nowhere better to put it.
+        console.error(`Could not ${action}`, error);
     }
 }
 </script>
 
 <style lang="scss" scoped>
+.confirm {
+    width: 352px;
+}
+
+.status-anchor {
+    position: relative;
+}
+
+.status-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 20;
+    min-width: 100%;
+    white-space: nowrap;
+    background: #111;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.5);
+
+    // Button's own active prop applies a class that nothing styles, so the
+    // current entry is marked here instead.
+    .current {
+        background-color: rgba(255, 255, 255, 0.25);
+        font-weight: bold;
+    }
+}
+
 .server-status-dot {
     font-size: 12px;
     margin-right: 4px;
 
     &.online {
         color: rgb(121, 226, 0);
+    }
+
+    &.busy {
+        color: rgb(226, 170, 0);
     }
 
     &.offline {

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -89,6 +89,11 @@ async function serverChanged() {
     await logout();
 }
 
+// Main persists the identity off this same event and that is what gets read back
+// on startup, but db.users is still where anything looking up a user by id goes,
+// the profile view included, so our own record has to be in there too.
+// TODO tidy this up: the row is a snapshot of the whole reactive object, written
+// in two steps that aren't in one transaction, and nothing reads isMe any more.
 window.tachyon.onEvent("user/self", async (event) => {
     console.debug(`Received user/self event: ${JSON.stringify(event)}`);
     if (event && event.user) {
@@ -267,14 +272,12 @@ export async function initMeStore() {
         }
     });
 
-    await db.users
-        .where({ isMe: 1 })
-        .first()
-        .then((user) => {
-            if (user) {
-                Object.assign(me, user);
-            }
-        });
+    // Last known, from whenever we were last connected. Absent on a fresh
+    // install, in which case the defaults stand in until a socket says otherwise.
+    const identity = await window.auth.getIdentity();
+    if (identity) {
+        Object.assign(me, identity);
+    }
 
     await syncAuthState();
     await restorePreviousSession();

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -296,13 +296,13 @@ async function restorePreviousSession() {
         // browser window while the user is still looking at the loading screen.
         await goOnline();
     } catch (error) {
-        // This runs before the UI mounts, so there is nowhere to show a retry.
-        // Signing out matters when the token was fine and the socket was refused
-        // anyway, say for a ban or a version the server no longer speaks: without
-        // it the UI claims a session and nothing retries, because a connection
-        // that never opened never fires a disconnect.
+        // Deliberately keeps the credentials. Whatever went wrong here, only main
+        // can tell a rejected refresh token from a server that was unreachable,
+        // and it already destroys the account in the first case. Signing out from
+        // here as well threw away working credentials over a laptop that woke up
+        // before its wifi did. Signed in and not connected is a state the status
+        // menu can get you out of.
         console.warn("Could not restore the previous session, continuing offline", error);
-        await logout();
 
         return;
     }

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -64,8 +64,14 @@ async function login(interactive = true) {
     }
 }
 
-async function playOffline() {
-    await logout();
+// Signing in and opening the socket are separate steps, and starting offline
+// leaves the first one undone, so going online has to cover both.
+async function goOnline() {
+    if (!me.isAuthenticated) {
+        await login(false);
+    }
+
+    await window.tachyon.connect();
 }
 
 async function logout() {
@@ -74,22 +80,13 @@ async function logout() {
     await syncAuthState();
 }
 
-async function changeAccount() {
-    await window.auth.wipe();
-    await syncAuthState();
-}
-
 // The same setting picks the websocket and the authorization server, so the
 // credentials we are holding were issued by the server being left and are worth
 // nothing to the one being joined. Switching ends the session rather than moving
-// the socket over.
+// the socket over, and logout is already that: it gives up wanting a connection
+// before closing one, so the drop is not taken for a fault worth retrying.
 async function serverChanged() {
-    // A socket that drops while we still look authenticated is treated as a
-    // connection worth retrying, so give up the session before closing it.
-    me.isAuthenticated = false;
-    subsManager.clearAllFromList(friendsSymbol);
-    await window.tachyon.disconnect();
-    await window.auth.wipe();
+    await logout();
 }
 
 window.tachyon.onEvent("user/self", async (event) => {
@@ -156,7 +153,7 @@ function clearOnlineState() {
 }
 
 // export const me = readonly(_me);
-export const auth = { login, playOffline, logout, changeAccount, clearOnlineState };
+export const auth = { login, goOnline, logout, clearOnlineState };
 
 // Friend methods
 export const friends = {
@@ -292,13 +289,9 @@ async function restorePreviousSession() {
     if (!(await window.auth.hasCredentials())) return;
 
     try {
-        // Non-interactive: a rejected refresh token must not open a browser
-        // window while the user is still looking at the loading screen.
-        await login(false);
-
-        // Holding a token is not being online, so the socket has to be opened
-        // here too, or the UI shows a session with nothing behind it.
-        await window.tachyon.connect();
+        // Non-interactive, because a rejected refresh token must not open a
+        // browser window while the user is still looking at the loading screen.
+        await goOnline();
     } catch (error) {
         // This runs before the UI mounts, so there is nowhere to show a retry.
         // Signing out matters when the token was fine and the socket was refused

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -71,7 +71,7 @@ async function goOnline() {
         await login(false);
     }
 
-    await window.tachyon.connect();
+    await tachyon.connect();
 }
 
 async function logout() {

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -5,7 +5,7 @@
 import { Me } from "@main/model/user";
 import { db } from "@renderer/store/db";
 import { reactive, toRaw, watch } from "vue";
-import { tachyon, tachyonStore } from "@renderer/store/tachyon.store";
+import { tachyon } from "@renderer/store/tachyon.store";
 import { PrivateUser } from "tachyon-protocol/types";
 import { settingsStore } from "@renderer/store/settings.store";
 import { subsManager } from "@renderer/store/users.store";
@@ -47,30 +47,36 @@ async function unsubscribeFromUsers(userIds: string[]) {
     subsManager.detach(userIds, friendsSymbol);
 }
 
-async function login() {
+// The main process owns the session. Nothing here assigns isAuthenticated
+// directly, or the UI can end up claiming a session that no longer exists.
+async function syncAuthState() {
+    const { authenticated } = await window.auth.getState();
+    me.isAuthenticated = authenticated;
+}
+
+async function login(interactive = true) {
     try {
-        await window.auth.login();
-        me.isAuthenticated = true;
-    } catch (e) {
-        console.error(e);
-        me.isAuthenticated = false;
-        throw e;
+        await window.auth.login(interactive);
+    } finally {
+        // The change event and this reply are separate channels, so read the
+        // state back rather than racing them.
+        await syncAuthState();
     }
 }
 
-function playOffline() {
-    me.isAuthenticated = false;
+async function playOffline() {
+    await logout();
 }
 
 async function logout() {
     await tachyon.goOffline();
-    window.auth.logout();
-    me.isAuthenticated = false;
+    await window.auth.logout();
+    await syncAuthState();
 }
 
 async function changeAccount() {
     await window.auth.wipe();
-    me.isAuthenticated = false;
+    await syncAuthState();
 }
 
 // The same setting picks the websocket and the authorization server, so the
@@ -250,6 +256,11 @@ export async function initMeStore() {
             void serverChanged();
         }
     );
+
+    window.auth.onChanged(({ authenticated }) => {
+        me.isAuthenticated = authenticated;
+    });
+
     onWentOffline.add(clearOnlineState);
     window.tachyon.onConnected(() => {
         // Subscriptions don't survive the socket, so rebuild them from the server's friend list
@@ -267,21 +278,42 @@ export async function initMeStore() {
                 Object.assign(me, user);
             }
         });
-    const hasCredentials = await window.auth.hasCredentials();
-    if (hasCredentials) {
-        try {
-            await login();
 
-            if (tachyonStore.isConnected) {
-                await friends.fetchFriendList();
-            }
-        } catch (error) {
-            // Auth renewal runs before the UI mounts, so there's no way to show
-            // a retry dialog here. Log the failure and continue — the user will
-            // see they're not logged in and can retry from the UI.
-            console.warn("Auth failed during startup, continuing offline", error);
-        }
-    }
+    await syncAuthState();
+    await restorePreviousSession();
 
     me.isInitialized = true;
+}
+
+// Multiplayer is behind devMode, so outside it there is no session to restore.
+async function restorePreviousSession() {
+    if (!settingsStore.devMode) return;
+    if (!settingsStore.loginAutomatically) return;
+    if (!(await window.auth.hasCredentials())) return;
+
+    try {
+        // Non-interactive: a rejected refresh token must not open a browser
+        // window while the user is still looking at the loading screen.
+        await login(false);
+
+        // Holding a token is not being online, so the socket has to be opened
+        // here too, or the UI shows a session with nothing behind it.
+        await window.tachyon.connect();
+    } catch (error) {
+        // This runs before the UI mounts, so there is nowhere to show a retry.
+        // Signing out matters when the token was fine and the socket was refused
+        // anyway, say for a ban or a version the server no longer speaks: without
+        // it the UI claims a session and nothing retries, because a connection
+        // that never opened never fires a disconnect.
+        console.warn("Could not restore the previous session, continuing offline", error);
+        await logout();
+
+        return;
+    }
+
+    try {
+        await friends.fetchFriendList();
+    } catch (error) {
+        console.warn("Could not fetch the friend list", error);
+    }
 }

--- a/src/renderer/store/tachyon.store.ts
+++ b/src/renderer/store/tachyon.store.ts
@@ -155,10 +155,12 @@ export async function initTachyonStore() {
         if (!wasConnected) return;
 
         stopFetchingServerStats();
-        // A close the user asked for is not a fault, so it gets no retry. Anything
-        // else while they still want to be online does. The overlay that goes up
-        // with the retries is what tells the user, so there is no alert here.
-        if (me.isAuthenticated && tachyonStore.wantsConnection) {
+        // A close the user asked for is not a fault, so it gets no retry.
+        // wantsConnection is the only thing consulted here: pairing it with a
+        // second flag meant the two could disagree about whether a close was
+        // deliberate. The overlay that goes up with the retries is what tells the
+        // user, so there is no alert either.
+        if (tachyonStore.wantsConnection) {
             startReconnecting();
         }
     });
@@ -172,6 +174,15 @@ export async function initTachyonStore() {
 
         console.debug("Network went away, dropping the connection");
         void window.tachyon.dropConnection();
+    });
+
+    // Losing the session is not something to retry through, whoever ended it, so
+    // the intent goes with it rather than being cleared at each call site.
+    window.auth.onChanged(({ authenticated }) => {
+        if (authenticated) return;
+
+        tachyonStore.wantsConnection = false;
+        stopReconnecting();
     });
 
     window.tachyon.onBattleStart((springString, data) => {

--- a/src/renderer/store/tachyon.store.ts
+++ b/src/renderer/store/tachyon.store.ts
@@ -34,7 +34,6 @@ export const tachyonStore = reactive({
 async function connect() {
     if (!me.isAuthenticated) throw new Error("Not authenticated");
 
-    tachyonStore.wantsConnection = true;
     try {
         await window.tachyon.connect();
         tachyonStore.error = undefined;
@@ -126,6 +125,10 @@ export async function initTachyonStore() {
     window.tachyon.onConnected(() => {
         console.debug("Connected to Tachyon server");
         tachyonStore.isConnected = true;
+        // Recorded here rather than in connect(), so it holds however the
+        // connection was opened. Setting it at one call site meant the others
+        // silently opted out of reconnecting.
+        tachyonStore.wantsConnection = true;
         fetchServerStats();
         stopFetchingServerStats();
         stopReconnecting();

--- a/src/renderer/views/index.vue
+++ b/src/renderer/views/index.vue
@@ -22,7 +22,6 @@ SPDX-License-Identifier: MIT
             </div>
             <div v-else class="buttons-container">
                 <button class="login-button" @click="login">{{ t("lobby.views.index.login") }}</button>
-                <div v-if="hasCredentials" class="play-offline" @click="changeAccount">{{ t("lobby.views.index.changeAccount") }}</div>
                 <div v-if="error" class="txt-error">{{ error }}</div>
                 <div class="play-offline" @click="playOffline">{{ t("lobby.views.index.playOffline") }}</div>
             </div>
@@ -46,10 +45,7 @@ const router = useRouter();
 const connecting = ref(false);
 const error = ref<string>();
 
-const hasCredentials = ref(false);
 onActivated(async () => {
-    hasCredentials.value = await window.auth.hasCredentials();
-
     // The store restores a previous session before the UI mounts, so there is
     // nothing to log in to here.
     if (me.isAuthenticated) {
@@ -93,14 +89,9 @@ async function abort() {
     router.push("/");
 }
 
-async function changeAccount() {
-    await auth.changeAccount();
-    hasCredentials.value = false;
-    login();
-}
-
-async function playOffline() {
-    await auth.playOffline();
+// Deliberately leaves the stored credentials alone; being signed in without a
+// connection is a valid state to sit in.
+function playOffline() {
     router.push("/play");
 }
 </script>

--- a/src/renderer/views/index.vue
+++ b/src/renderer/views/index.vue
@@ -36,8 +36,7 @@ import { useTypedI18n } from "@renderer/i18n";
 
 import Loader from "@renderer/components/common/Loader.vue";
 import { useRouter } from "vue-router";
-import { auth } from "@renderer/store/me.store";
-import { settingsStore } from "@renderer/store/settings.store";
+import { auth, me } from "@renderer/store/me.store";
 import { tachyon } from "@renderer/store/tachyon.store";
 
 const { t } = useTypedI18n();
@@ -50,6 +49,15 @@ const error = ref<string>();
 const hasCredentials = ref(false);
 onActivated(async () => {
     hasCredentials.value = await window.auth.hasCredentials();
+
+    // The store restores a previous session before the UI mounts, so there is
+    // nothing to log in to here.
+    if (me.isAuthenticated) {
+        const redirect = router.currentRoute.value.query.redirect as string | undefined;
+        await router.replace(redirect || "/play");
+
+        return;
+    }
 
     if (router.currentRoute.value.query.login === "true") {
         const query = { ...router.currentRoute.value.query };
@@ -92,13 +100,8 @@ async function changeAccount() {
 }
 
 async function playOffline() {
-    auth.playOffline();
+    await auth.playOffline();
     router.push("/play");
-}
-
-if (hasCredentials.value && settingsStore.loginAutomatically) {
-    console.log("Logging in automatically");
-    login();
 }
 </script>
 

--- a/tests/unit/main/account-store.spec.ts
+++ b/tests/unit/main/account-store.spec.ts
@@ -155,16 +155,6 @@ describe("account store", () => {
         expect(accountService.getToken()).toBe("");
     });
 
-    it("keeps the refresh token when only the access token is forgotten", async () => {
-        const accountService = await loadService();
-        await accountService.saveTokens(tokens);
-        await accountService.forgetToken();
-
-        expect(accountService.getToken()).toBe("");
-        expect(accountService.getExpiresAt()).toBe(0);
-        expect(accountService.getRefreshToken()).toBe("refresh-1");
-    });
-
     it("clears everything on a wipe", async () => {
         const accountService = await loadService();
         await accountService.saveTokens(tokens);

--- a/tests/unit/main/account-store.spec.ts
+++ b/tests/unit/main/account-store.spec.ts
@@ -155,6 +155,36 @@ describe("account store", () => {
         expect(accountService.getToken()).toBe("");
     });
 
+    // The name has to be readable before anything has connected, so it is not
+    // encrypted and it lives beside the credentials rather than in the renderer.
+    it("remembers who the credentials belong to across a restart", async () => {
+        const first = await loadService();
+        await first.saveIdentity({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+
+        const second = await loadService();
+        expect(second.getIdentity()).toEqual({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+    });
+
+    // Renewals write the token pair every few minutes, long after the identity
+    // was recorded, so they must not carry it away with them.
+    it("keeps the identity through a token renewal", async () => {
+        const accountService = await loadService();
+        await accountService.saveIdentity({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+        await accountService.saveTokens(tokens);
+
+        expect(accountService.getIdentity()).toBeDefined();
+        expect(onDisk().identity).toBeDefined();
+    });
+
+    it("forgets the identity along with the credentials", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+        await accountService.saveIdentity({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+        await accountService.wipe();
+
+        expect(accountService.getIdentity()).toBeUndefined();
+    });
+
     it("clears everything on a wipe", async () => {
         const accountService = await loadService();
         await accountService.saveTokens(tokens);

--- a/tests/unit/main/account-store.spec.ts
+++ b/tests/unit/main/account-store.spec.ts
@@ -120,6 +120,41 @@ describe("account store", () => {
         expect(reopened.getRefreshToken()).toBe("refresh-1");
     });
 
+    // Files written before the encrypted flag existed have to keep working, or
+    // everyone gets signed out by the upgrade.
+    it("decrypts a file from before the flag existed", async () => {
+        fs.writeFileSync(
+            accountFile(),
+            JSON.stringify({
+                token: Buffer.from("enc:access-1").toString("base64"),
+                refreshToken: Buffer.from("enc:refresh-1").toString("base64"),
+            })
+        );
+
+        const accountService = await loadService();
+
+        expect(accountService.getToken()).toBe("access-1");
+        expect(accountService.getRefreshToken()).toBe("refresh-1");
+    });
+
+    it("reads a plain value from before the flag existed", async () => {
+        fs.writeFileSync(accountFile(), JSON.stringify({ token: "access-1", refreshToken: "refresh-1" }));
+
+        const accountService = await loadService();
+
+        expect(accountService.getToken()).toBe("access-1");
+        expect(accountService.getRefreshToken()).toBe("refresh-1");
+    });
+
+    it("returns nothing for a file from before the flag when encryption is unavailable", async () => {
+        fs.writeFileSync(accountFile(), JSON.stringify({ token: Buffer.from("enc:access-1").toString("base64") }));
+        electronMock.state.available = false;
+
+        const accountService = await loadService();
+
+        expect(accountService.getToken()).toBe("");
+    });
+
     it("keeps the refresh token when only the access token is forgotten", async () => {
         const accountService = await loadService();
         await accountService.saveTokens(tokens);

--- a/tests/unit/main/account-store.spec.ts
+++ b/tests/unit/main/account-store.spec.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const store = vi.hoisted(() => ({ dir: "" }));
+
+const electronMock = vi.hoisted(() => {
+    const state = { available: true };
+
+    return {
+        state,
+        safeStorage: {
+            isEncryptionAvailable: () => state.available,
+            encryptString: (value: string) => Buffer.from(`enc:${value}`),
+            decryptString: (buffer: Buffer) => {
+                const raw = buffer.toString();
+                if (!raw.startsWith("enc:")) throw new Error("cannot decrypt");
+
+                return raw.slice(4);
+            },
+        },
+    };
+});
+
+vi.mock("electron", () => ({ safeStorage: electronMock.safeStorage }));
+vi.mock("@main/config/app", () => ({ CONFIG_PATH: store.dir }));
+
+const accountFile = () => path.join(store.dir, "account.json");
+const onDisk = () => JSON.parse(fs.readFileSync(accountFile(), "utf-8"));
+
+const tokens = { token: "access-1", refreshToken: "refresh-1", expiresAt: 1_800_000 };
+
+async function loadService() {
+    vi.resetModules();
+    const { accountService } = await import("@main/services/account.service");
+    await accountService.init();
+
+    return accountService;
+}
+
+beforeAll(() => {
+    store.dir = fs.mkdtempSync(path.join(os.tmpdir(), "bar-account-"));
+});
+
+afterAll(() => {
+    fs.rmSync(store.dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    fs.rmSync(accountFile(), { force: true });
+    electronMock.state.available = true;
+});
+
+describe("account store", () => {
+    it("round trips tokens without leaving them readable on disk", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+
+        const raw = fs.readFileSync(accountFile(), "utf-8");
+        expect(raw).not.toContain("access-1");
+        expect(raw).not.toContain("refresh-1");
+
+        expect(accountService.getToken()).toBe("access-1");
+        expect(accountService.getRefreshToken()).toBe("refresh-1");
+        expect(accountService.getExpiresAt()).toBe(1_800_000);
+    });
+
+    it("writes the pair and its expiry together", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+
+        const saved = onDisk();
+        expect(saved.token).toBeTruthy();
+        expect(saved.refreshToken).toBeTruthy();
+        expect(saved.expiresAt).toBe(1_800_000);
+        expect(saved.encrypted).toBe(true);
+    });
+
+    it("survives a restart", async () => {
+        const first = await loadService();
+        await first.saveTokens(tokens);
+
+        const second = await loadService();
+        expect(second.getToken()).toBe("access-1");
+        expect(second.getRefreshToken()).toBe("refresh-1");
+    });
+
+    it("falls back to plain text when encryption is unavailable", async () => {
+        electronMock.state.available = false;
+
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+
+        expect(onDisk().encrypted).toBe(false);
+        expect(accountService.getToken()).toBe("access-1");
+    });
+
+    it("returns nothing when the values were encrypted but encryption has gone away", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+
+        electronMock.state.available = false;
+
+        expect(accountService.getToken()).toBe("");
+        expect(accountService.getRefreshToken()).toBe("");
+    });
+
+    it("returns nothing for a value it cannot decrypt", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+        fs.writeFileSync(accountFile(), JSON.stringify({ ...onDisk(), token: Buffer.from("garbage").toString("base64") }));
+
+        const reopened = await loadService();
+        expect(reopened.getToken()).toBe("");
+        expect(reopened.getRefreshToken()).toBe("refresh-1");
+    });
+
+    it("keeps the refresh token when only the access token is forgotten", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+        await accountService.forgetToken();
+
+        expect(accountService.getToken()).toBe("");
+        expect(accountService.getExpiresAt()).toBe(0);
+        expect(accountService.getRefreshToken()).toBe("refresh-1");
+    });
+
+    it("clears everything on a wipe", async () => {
+        const accountService = await loadService();
+        await accountService.saveTokens(tokens);
+        await accountService.wipe();
+
+        expect(accountService.getToken()).toBe("");
+        expect(accountService.getRefreshToken()).toBe("");
+        expect(accountService.getExpiresAt()).toBe(0);
+    });
+});

--- a/tests/unit/main/auth-session.spec.ts
+++ b/tests/unit/main/auth-session.spec.ts
@@ -5,6 +5,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AuthState } from "@main/services/auth.service";
 
 const { TokenRequestError } = vi.hoisted(() => {
     class TokenRequestError extends Error {
@@ -295,5 +296,21 @@ describe("auth session policy", () => {
         await authService.init();
 
         expect(account.service.init).toHaveBeenCalled();
+    });
+
+    // Telling the renderer is one subscriber now rather than the thing that
+    // switches notification on, so a change before IPC is wired still gets heard.
+    it("reports a session change to a listener that is not the IPC bridge", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        vi.resetModules();
+        const { authService } = await import("@main/services/auth.service");
+        const heard: AuthState[] = [];
+        authService.onChanged.add((next) => void heard.push(next));
+
+        await authService.getAccessToken();
+
+        expect(heard).toEqual([{ authenticated: true }]);
     });
 });

--- a/tests/unit/main/auth-session.spec.ts
+++ b/tests/unit/main/auth-session.spec.ts
@@ -25,11 +25,14 @@ const oauth2 = vi.hoisted(() => ({
 }));
 
 const account = vi.hoisted(() => {
-    const state = { token: "", refreshToken: "", expiresAt: 0 };
+    const state = { token: "", refreshToken: "", expiresAt: 0, identity: undefined as unknown };
 
     return {
         state,
         service: {
+            init: vi.fn(async () => {}),
+            saveIdentity: vi.fn(async (identity: unknown) => void (state.identity = identity)),
+            getIdentity: () => state.identity,
             saveTokens: vi.fn(async ({ token, refreshToken, expiresAt }: any) => {
                 state.token = token;
                 state.refreshToken = refreshToken;
@@ -264,5 +267,33 @@ describe("auth session policy", () => {
         await vi.advanceTimersByTimeAsync(LIFETIME_SECONDS * 1000);
 
         expect(oauth2.renewAccessToken).not.toHaveBeenCalled();
+    });
+
+    // Identity reaches the session over the socket rather than from the token
+    // exchange, so it comes in through here instead of past the owner to the store.
+    it("stores an identity handed to it", async () => {
+        const { authService } = await loadService();
+
+        await authService.setIdentity({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+
+        expect(account.service.saveIdentity).toHaveBeenCalledWith({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+        expect(ipc.handlers.get("auth:identity")!()).toEqual({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" });
+    });
+
+    // Losing it costs the name shown before the next connection, which is not
+    // worth failing whoever handed it over.
+    it("swallows a failure to store the identity", async () => {
+        const { authService } = await loadService();
+        account.service.saveIdentity.mockRejectedValueOnce(new Error("disk full"));
+
+        await expect(authService.setIdentity({ userId: "42", username: "Hectwo", displayName: "Hectwo", countryCode: "GB" })).resolves.toBeUndefined();
+    });
+
+    it("brings the account store up itself rather than leaving it to the caller", async () => {
+        const { authService } = await loadService();
+
+        await authService.init();
+
+        expect(account.service.init).toHaveBeenCalled();
     });
 });

--- a/tests/unit/main/auth-session.spec.ts
+++ b/tests/unit/main/auth-session.spec.ts
@@ -43,10 +43,6 @@ const account = vi.hoisted(() => {
                 state.refreshToken = "";
                 state.expiresAt = 0;
             }),
-            forgetToken: vi.fn(async () => {
-                state.token = "";
-                state.expiresAt = 0;
-            }),
         },
     };
 });
@@ -230,7 +226,9 @@ describe("auth session policy", () => {
         await expect(authService.getAccessToken()).resolves.toBe("");
     });
 
-    it("keeps the refresh token on sign out but drops the access token", async () => {
+    // Leaving the refresh token behind is what made a separate "change account"
+    // action necessary, so signing out has to take both.
+    it("drops both tokens on sign out", async () => {
         account.state.refreshToken = "refresh-0";
         oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
 
@@ -239,20 +237,19 @@ describe("auth session policy", () => {
         await ipc.handlers.get("auth:logout")!();
 
         expect(account.state.token).toBe("");
-        expect(account.state.refreshToken).toBe("refresh-1");
+        expect(account.state.refreshToken).toBe("");
         expect(webContents.send).toHaveBeenCalledWith("auth:changed", { authenticated: false, reason: "signed-out" });
     });
 
-    it("drops both tokens when the account is forgotten", async () => {
+    it("leaves nothing to sign back in with", async () => {
         account.state.refreshToken = "refresh-0";
         oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
 
         await loadService();
         await signIn();
-        await ipc.handlers.get("auth:wipe")!();
+        await ipc.handlers.get("auth:logout")!();
 
-        expect(account.state.token).toBe("");
-        expect(account.state.refreshToken).toBe("");
+        expect(ipc.handlers.get("auth:hasCredentials")!()).toBe(false);
     });
 
     it("stops renewing after sign out", async () => {

--- a/tests/unit/main/auth-session.spec.ts
+++ b/tests/unit/main/auth-session.spec.ts
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { TokenRequestError } = vi.hoisted(() => {
+    class TokenRequestError extends Error {
+        readonly kind: string;
+
+        constructor(kind: string, message: string) {
+            super(message);
+            this.kind = kind;
+        }
+    }
+
+    return { TokenRequestError };
+});
+
+const oauth2 = vi.hoisted(() => ({
+    authenticate: vi.fn(),
+    renewAccessToken: vi.fn(),
+}));
+
+const account = vi.hoisted(() => {
+    const state = { token: "", refreshToken: "", expiresAt: 0 };
+
+    return {
+        state,
+        service: {
+            saveTokens: vi.fn(async ({ token, refreshToken, expiresAt }: any) => {
+                state.token = token;
+                state.refreshToken = refreshToken;
+                state.expiresAt = expiresAt;
+            }),
+            getToken: () => state.token,
+            getRefreshToken: () => state.refreshToken,
+            getExpiresAt: () => state.expiresAt,
+            wipe: vi.fn(async () => {
+                state.token = "";
+                state.refreshToken = "";
+                state.expiresAt = 0;
+            }),
+            forgetToken: vi.fn(async () => {
+                state.token = "";
+                state.expiresAt = 0;
+            }),
+        },
+    };
+});
+
+const ipc = vi.hoisted(() => ({ handlers: new Map<string, any>() }));
+
+vi.mock("@main/oauth2/oauth2", () => ({ ...oauth2, TokenRequestError }));
+vi.mock("@main/services/account.service", () => ({ accountService: account.service }));
+vi.mock("@main/utils/logger", () => ({
+    logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock("@main/typed-ipc", () => ({
+    ipcMain: { handle: (channel: string, handler: any) => ipc.handlers.set(channel, handler) },
+}));
+
+const LIFETIME_SECONDS = 1800;
+const RENEWAL_DUE_MS = (LIFETIME_SECONDS * 1000) / 2 + 10;
+
+const freshTokens = (suffix: string) => ({
+    token: `access-${suffix}`,
+    refreshToken: `refresh-${suffix}`,
+    expiresIn: LIFETIME_SECONDS,
+});
+
+async function loadService() {
+    vi.resetModules();
+    ipc.handlers.clear();
+
+    const webContents = { send: vi.fn() };
+    const { authService } = await import("@main/services/auth.service");
+    authService.registerIpcHandlers(webContents as any);
+
+    return { authService, webContents };
+}
+
+const signIn = (interactive = true) => ipc.handlers.get("auth:login")!(null, interactive);
+
+describe("auth session policy", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        oauth2.authenticate.mockReset();
+        oauth2.renewAccessToken.mockReset();
+        account.state.token = "";
+        account.state.refreshToken = "";
+        account.state.expiresAt = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("persists the rotated refresh token", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        await loadService();
+        await signIn();
+
+        expect(account.service.saveTokens).toHaveBeenCalledWith(expect.objectContaining({ token: "access-1", refreshToken: "refresh-1" }));
+        expect(account.state.refreshToken).toBe("refresh-1");
+    });
+
+    it("keeps credentials when a renewal fails for a transient reason", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockRejectedValueOnce(new TokenRequestError("server", "bad gateway"));
+
+        const { webContents } = await loadService();
+        await signIn();
+        await vi.advanceTimersByTimeAsync(RENEWAL_DUE_MS);
+
+        expect(account.service.wipe).not.toHaveBeenCalled();
+        expect(account.state.refreshToken).toBe("refresh-1");
+        expect(webContents.send).not.toHaveBeenCalledWith("auth:changed", expect.objectContaining({ authenticated: false }));
+    });
+
+    it("retries a transient failure without a further sign in", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockRejectedValueOnce(new TokenRequestError("network", "offline")).mockResolvedValueOnce(freshTokens("2"));
+
+        await loadService();
+        await signIn();
+        await vi.advanceTimersByTimeAsync(RENEWAL_DUE_MS);
+        await vi.advanceTimersByTimeAsync(60 * 1000 + 10);
+
+        expect(account.state.refreshToken).toBe("refresh-2");
+    });
+
+    it("wipes and reports expiry when the server rejects the refresh token", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockRejectedValueOnce(new TokenRequestError("invalid_grant", "revoked"));
+
+        const { webContents } = await loadService();
+        await signIn();
+        await vi.advanceTimersByTimeAsync(RENEWAL_DUE_MS);
+
+        expect(account.service.wipe).toHaveBeenCalled();
+        expect(webContents.send).toHaveBeenCalledWith("auth:changed", { authenticated: false, reason: "expired" });
+    });
+
+    it("falls back to interactive sign in when the stored refresh token is rejected", async () => {
+        account.state.refreshToken = "stale";
+        oauth2.renewAccessToken.mockRejectedValue(new TokenRequestError("invalid_grant", "revoked"));
+        oauth2.authenticate.mockResolvedValue(freshTokens("1"));
+
+        await loadService();
+        await signIn();
+
+        expect(oauth2.authenticate).toHaveBeenCalled();
+        expect(account.state.refreshToken).toBe("refresh-1");
+    });
+
+    it("does not open a browser for a non-interactive sign in", async () => {
+        account.state.refreshToken = "stale";
+        oauth2.renewAccessToken.mockRejectedValue(new TokenRequestError("invalid_grant", "revoked"));
+
+        await loadService();
+
+        await expect(signIn(false)).rejects.toThrow();
+        expect(oauth2.authenticate).not.toHaveBeenCalled();
+    });
+
+    it("gives up once a transient failure outlasts the access token", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockRejectedValue(new TokenRequestError("server", "still down"));
+
+        const { webContents } = await loadService();
+        await signIn();
+        await vi.advanceTimersByTimeAsync(LIFETIME_SECONDS * 1000);
+
+        expect(webContents.send).toHaveBeenCalledWith("auth:changed", { authenticated: false, reason: "error" });
+        expect(account.service.wipe).not.toHaveBeenCalled();
+    });
+
+    it("announces each transition once", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        const { webContents } = await loadService();
+        await signIn();
+        await vi.advanceTimersByTimeAsync(RENEWAL_DUE_MS);
+
+        const announcements = webContents.send.mock.calls.filter(([channel]) => channel === "auth:changed");
+        expect(announcements).toEqual([["auth:changed", { authenticated: true, reason: undefined }]]);
+    });
+
+    it("hands out the stored token while it is still good", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        const { authService } = await loadService();
+        await signIn();
+
+        await expect(authService.getAccessToken()).resolves.toBe("access-1");
+        expect(oauth2.renewAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    it("renews on demand when the stored token has expired", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockResolvedValueOnce(freshTokens("2"));
+
+        const { authService } = await loadService();
+        await signIn();
+        account.state.expiresAt = Date.now() - 1;
+
+        await expect(authService.getAccessToken()).resolves.toBe("access-2");
+    });
+
+    it("hands out nothing when an on demand renewal fails", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValueOnce(freshTokens("1")).mockRejectedValueOnce(new TokenRequestError("server", "down"));
+
+        const { authService } = await loadService();
+        await signIn();
+        account.state.expiresAt = Date.now() - 1;
+
+        await expect(authService.getAccessToken()).resolves.toBe("");
+    });
+
+    it("keeps the refresh token on sign out but drops the access token", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        const { webContents } = await loadService();
+        await signIn();
+        await ipc.handlers.get("auth:logout")!();
+
+        expect(account.state.token).toBe("");
+        expect(account.state.refreshToken).toBe("refresh-1");
+        expect(webContents.send).toHaveBeenCalledWith("auth:changed", { authenticated: false, reason: "signed-out" });
+    });
+
+    it("drops both tokens when the account is forgotten", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        await loadService();
+        await signIn();
+        await ipc.handlers.get("auth:wipe")!();
+
+        expect(account.state.token).toBe("");
+        expect(account.state.refreshToken).toBe("");
+    });
+
+    it("stops renewing after sign out", async () => {
+        account.state.refreshToken = "refresh-0";
+        oauth2.renewAccessToken.mockResolvedValue(freshTokens("1"));
+
+        await loadService();
+        await signIn();
+        await ipc.handlers.get("auth:logout")!();
+
+        oauth2.renewAccessToken.mockClear();
+        await vi.advanceTimersByTimeAsync(LIFETIME_SECONDS * 1000);
+
+        expect(oauth2.renewAccessToken).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/main/auth-session.spec.ts
+++ b/tests/unit/main/auth-session.spec.ts
@@ -64,6 +64,7 @@ vi.mock("@main/typed-ipc", () => ({
 
 const LIFETIME_SECONDS = 1800;
 const RENEWAL_DUE_MS = (LIFETIME_SECONDS * 1000) / 2 + 10;
+const TRANSIENT_RETRY_MS = 60 * 1000;
 
 const freshTokens = (suffix: string) => ({
     token: `access-${suffix}`,
@@ -175,7 +176,10 @@ describe("auth session policy", () => {
 
         const { webContents } = await loadService();
         await signIn();
-        await vi.advanceTimersByTimeAsync(LIFETIME_SECONDS * 1000);
+
+        // Past the lifetime plus a retry interval, so a retry is guaranteed to
+        // fire after expiry whatever the renewal fraction is set to.
+        await vi.advanceTimersByTimeAsync(LIFETIME_SECONDS * 1000 + TRANSIENT_RETRY_MS);
 
         expect(webContents.send).toHaveBeenCalledWith("auth:changed", { authenticated: false, reason: "error" });
         expect(account.service.wipe).not.toHaveBeenCalled();

--- a/tests/unit/main/file-store.spec.ts
+++ b/tests/unit/main/file-store.spec.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Type } from "@sinclair/typebox";
+
+import { FileStore } from "@main/json/file-store";
+
+const schema = Type.Object({
+    first: Type.String({ default: "" }),
+    second: Type.String({ default: "" }),
+    count: Type.Number({ default: 0 }),
+});
+
+let dir: string;
+let file: string;
+
+const onDisk = () => JSON.parse(fs.readFileSync(file, "utf-8"));
+
+async function newStore() {
+    const store = new FileStore<typeof schema>(file, schema);
+    await store.init();
+
+    return store;
+}
+
+beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "bar-file-store-"));
+});
+
+afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    file = path.join(dir, `store-${Math.random().toString(36).slice(2)}.json`);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("file store", () => {
+    it("applies overlapping updates without losing any of them", async () => {
+        const store = await newStore();
+
+        await Promise.all([store.update({ first: "a" }), store.update({ second: "b" }), store.update({ count: 3 })]);
+
+        expect(onDisk()).toMatchObject({ first: "a", second: "b", count: 3 });
+    });
+
+    it("leaves the file valid JSON after concurrent writes", async () => {
+        const store = await newStore();
+
+        await Promise.all(Array.from({ length: 20 }, (_unused, i) => store.update({ count: i })));
+
+        expect(() => onDisk()).not.toThrow();
+    });
+
+    it("replaces the file by rename and leaves no temp file behind", async () => {
+        const rename = vi.spyOn(fs.promises, "rename");
+        const store = await newStore();
+
+        await store.update({ first: "a" });
+
+        expect(rename).toHaveBeenCalled();
+        expect(fs.existsSync(`${file}.tmp`)).toBe(false);
+    });
+
+    it("keeps the previous contents when a write fails", async () => {
+        const store = await newStore();
+        await store.update({ first: "before" });
+
+        vi.spyOn(fs.promises, "rename").mockRejectedValueOnce(new Error("locked"));
+
+        await expect(store.update({ first: "after" })).rejects.toThrow("locked");
+        expect(onDisk().first).toBe("before");
+    });
+
+    it("still writes after a failed write", async () => {
+        const store = await newStore();
+        await store.update({ first: "before" });
+
+        vi.spyOn(fs.promises, "rename").mockRejectedValueOnce(new Error("locked"));
+        await expect(store.update({ second: "x" })).rejects.toThrow("locked");
+
+        vi.restoreAllMocks();
+        await store.update({ second: "after" });
+
+        expect(onDisk().second).toBe("after");
+    });
+
+    it("reads back what a previous instance wrote", async () => {
+        const first = await newStore();
+        await first.update({ first: "persisted", count: 7 });
+
+        const second = await newStore();
+
+        expect(second.model.first).toBe("persisted");
+        expect(second.model.count).toBe(7);
+    });
+});

--- a/tests/unit/main/main-process-lifecycle.spec.ts
+++ b/tests/unit/main/main-process-lifecycle.spec.ts
@@ -17,14 +17,13 @@ describe("Main Process Lifecycle", () => {
     const mockServices = {
         engineService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         settingsService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn(), getSettings: vi.fn().mockReturnValue({ assetsPath: "" }) },
-        accountService: { init: vi.fn().mockResolvedValue(undefined) },
         replaysService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         gameService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         mapsService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         autoUpdaterService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         logService: { registerIpcHandlers: vi.fn() },
         infoService: { registerIpcHandlers: vi.fn() },
-        authService: { registerIpcHandlers: vi.fn() },
+        authService: { init: vi.fn().mockResolvedValue(undefined), registerIpcHandlers: vi.fn() },
         tachyonService: { registerIpcHandlers: vi.fn() },
         shellService: { registerIpcHandlers: vi.fn() },
         downloadsService: { registerIpcHandlers: vi.fn() },
@@ -123,7 +122,6 @@ describe("Main Process Lifecycle", () => {
 
         vi.doMock("@main/services/settings.service", () => ({ settingsService: mockServices.settingsService }));
         vi.doMock("@main/services/info.service", () => ({ infoService: mockServices.infoService }));
-        vi.doMock("@main/services/account.service", () => ({ accountService: mockServices.accountService }));
         vi.doMock("@main/services/log.service", () => ({ logService: mockServices.logService }));
         vi.doMock("@main/services/auth.service", () => ({ authService: mockServices.authService }));
         vi.doMock("@main/services/tachyon.service", () => ({ tachyonService: mockServices.tachyonService }));
@@ -211,7 +209,7 @@ describe("Main Process Lifecycle", () => {
 
         expect(mockServices.engineService.init).toHaveBeenCalled();
         expect(mockServices.settingsService.init).toHaveBeenCalled();
-        expect(mockServices.accountService.init).toHaveBeenCalled();
+        expect(mockServices.authService.init).toHaveBeenCalled();
         expect(mockServices.replaysService.init).toHaveBeenCalled();
         expect(mockServices.gameService.init).toHaveBeenCalled();
         expect(mockServices.mapsService.init).toHaveBeenCalled();

--- a/tests/unit/main/oauth2-client.spec.ts
+++ b/tests/unit/main/oauth2-client.spec.ts
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const SERVER = "https://lobby.example.com";
+const WELL_KNOWN = `${SERVER}/.well-known/oauth-authorization-server`;
+const TOKEN_ENDPOINT = `${SERVER}/oauth/token`;
+const REDIRECT_URI = "http://127.0.0.1:12345/oauth2callback";
+
+const redirect = vi.hoisted(() => ({
+    start: vi.fn(),
+    waitForCallback: vi.fn(),
+    close: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ shell: { openExternal: vi.fn() } }));
+
+vi.mock("@main/config/server", () => ({
+    OAUTH_CLIENT_ID: "generic_lobby",
+    OAUTH_SCOPE: "tachyon.lobby",
+    getOAuthAuthorizationServerURL: () => SERVER,
+    getOAuthWellKnownURL: () => WELL_KNOWN,
+}));
+
+vi.mock("@main/oauth2/redirect-handler", () => ({
+    default: class {
+        start = redirect.start;
+        waitForCallback = redirect.waitForCallback;
+        close = redirect.close;
+    },
+}));
+
+import { authenticate, renewAccessToken, TokenRequestError } from "@main/oauth2/oauth2";
+
+const metadata = {
+    issuer: SERVER,
+    authorization_endpoint: `${SERVER}/oauth/authorize`,
+    token_endpoint: TOKEN_ENDPOINT,
+};
+
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+const text = (body: string, status = 200) => new Response(body, { status });
+
+const tokens = { access_token: "access-1", refresh_token: "refresh-1", expires_in: 1800 };
+
+let fetchMock: any;
+
+function respondWith(...responses: (Response | Error)[]) {
+    for (const response of responses) {
+        if (response instanceof Error) {
+            fetchMock.mockRejectedValueOnce(response);
+        } else {
+            fetchMock.mockResolvedValueOnce(response);
+        }
+    }
+}
+
+function tokenRequestBody(): URLSearchParams {
+    const call = fetchMock.mock.calls.find(([url]: [string]) => url === TOKEN_ENDPOINT);
+    expect(call).toBeDefined();
+
+    return call[1].body as URLSearchParams;
+}
+
+async function kindOfThrown(run: () => Promise<unknown>): Promise<string> {
+    try {
+        await run();
+    } catch (error) {
+        expect(error).toBeInstanceOf(TokenRequestError);
+
+        return (error as TokenRequestError).kind;
+    }
+
+    throw new Error("expected the call to throw");
+}
+
+beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    redirect.start.mockResolvedValue(REDIRECT_URI);
+    redirect.waitForCallback.mockResolvedValue(new URL(`${REDIRECT_URI}?code=auth-code`));
+    redirect.close.mockClear();
+});
+
+describe("authorization server metadata", () => {
+    it("rejects an issuer that is not the configured server", async () => {
+        respondWith(json({ ...metadata, issuer: "https://elsewhere.example.com" }));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("rejects endpoints that live off the authorization server", async () => {
+        respondWith(json({ ...metadata, token_endpoint: "https://lobby.example.com.evil.test/oauth/token" }));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("treats a server error as transient", async () => {
+        respondWith(text("upstream down", 502));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("server");
+    });
+
+    it("rejects a body that is not JSON", async () => {
+        respondWith(text("<html>nope</html>"));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("reports an unreachable server as a network failure", async () => {
+        respondWith(new TypeError("fetch failed"));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("network");
+    });
+});
+
+describe("token requests", () => {
+    it("sends the refresh grant as a form encoded body, not a query string", async () => {
+        respondWith(json(metadata), json(tokens));
+
+        await renewAccessToken("refresh-0");
+
+        const [url, init] = fetchMock.mock.calls[1];
+        expect(url).toBe(TOKEN_ENDPOINT);
+        expect(url).not.toContain("?");
+        expect(init.method).toBe("POST");
+        expect(init.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+
+        const body = tokenRequestBody();
+        expect(body.get("grant_type")).toBe("refresh_token");
+        expect(body.get("refresh_token")).toBe("refresh-0");
+        expect(body.get("client_id")).toBe("generic_lobby");
+        expect(body.get("scope")).toBe("tachyon.lobby");
+    });
+
+    it("sends the code exchange as a form encoded body carrying the verifier", async () => {
+        respondWith(json(metadata), json(tokens));
+
+        await authenticate();
+
+        const [url, init] = fetchMock.mock.calls[1];
+        expect(url).toBe(TOKEN_ENDPOINT);
+        expect(url).not.toContain("?");
+
+        const body = tokenRequestBody();
+        expect(body.get("grant_type")).toBe("authorization_code");
+        expect(body.get("code")).toBe("auth-code");
+        expect(body.get("redirect_uri")).toBe(REDIRECT_URI);
+        expect(body.get("code_verifier")).toBeTruthy();
+        expect(init.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    });
+});
+
+describe("token error classification", () => {
+    it("marks a rejected grant so the session can be dropped", async () => {
+        respondWith(json(metadata), json({ error: "invalid_grant", error_description: "token revoked" }, 400));
+
+        const kind = await kindOfThrown(() => renewAccessToken("refresh-0"));
+        expect(kind).toBe("invalid_grant");
+    });
+
+    it("includes the server description in the message", async () => {
+        respondWith(json(metadata), json({ error: "invalid_grant", error_description: "token revoked" }, 400));
+
+        await expect(renewAccessToken("refresh-0")).rejects.toThrow(/token revoked/);
+    });
+
+    it("marks a 500 from the token endpoint as transient", async () => {
+        respondWith(json(metadata), json({ error: "server_error" }, 500));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("server");
+    });
+
+    it("marks other rejections as protocol failures", async () => {
+        respondWith(json(metadata), json({ error: "invalid_request" }, 400));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("copes with an error body that is not JSON", async () => {
+        respondWith(json(metadata), new Response("gateway timeout", { status: 504, statusText: "Gateway Timeout" }));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("server");
+    });
+});
+
+describe("token response validation", () => {
+    it("keeps the current refresh token when the server does not rotate it", async () => {
+        respondWith(json(metadata), json({ access_token: "access-1", expires_in: 1800 }));
+
+        await expect(renewAccessToken("refresh-0")).resolves.toEqual({
+            token: "access-1",
+            refreshToken: "refresh-0",
+            expiresIn: 1800,
+        });
+    });
+
+    it("rejects a response with no access token", async () => {
+        respondWith(json(metadata), json({ refresh_token: "refresh-1", expires_in: 1800 }));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("rejects a lifetime it cannot schedule against", async () => {
+        respondWith(json(metadata), json({ access_token: "access-1", expires_in: null }));
+
+        expect(await kindOfThrown(() => renewAccessToken("refresh-0"))).toBe("protocol");
+    });
+
+    it("requires a refresh token on a first sign in", async () => {
+        respondWith(json(metadata), json({ access_token: "access-1", expires_in: 1800 }));
+
+        expect(await kindOfThrown(() => authenticate())).toBe("protocol");
+    });
+});
+
+describe("interactive sign in", () => {
+    it("reports a denied consent screen", async () => {
+        respondWith(json(metadata));
+        redirect.waitForCallback.mockResolvedValue(new URL(`${REDIRECT_URI}?error=access_denied`));
+
+        await expect(authenticate()).rejects.toThrow(/access_denied/);
+    });
+
+    it("closes the loopback server even when the exchange fails", async () => {
+        respondWith(json(metadata), json({ error: "invalid_request" }, 400));
+
+        await expect(authenticate()).rejects.toThrow();
+        expect(redirect.close).toHaveBeenCalled();
+    });
+});

--- a/tests/unit/renderer/auth-projection.spec.ts
+++ b/tests/unit/renderer/auth-projection.spec.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const settings = vi.hoisted(() => ({ devMode: true, loginAutomatically: true }));
+
+vi.mock("@renderer/store/settings.store", () => ({ settingsStore: settings }));
+
+// The cached user row carries whatever the last run persisted, including a
+// stale session flag, so it must never win over the main process.
+const storedUser = vi.hoisted(() => ({ current: undefined as Record<string, unknown> | undefined }));
+
+vi.mock("@renderer/store/db", () => ({
+    db: {
+        users: {
+            where: () => ({
+                first: async () => storedUser.current,
+                modify: async () => undefined,
+            }),
+            put: async () => undefined,
+        },
+    },
+}));
+
+vi.mock("@renderer/store/users.store", () => ({
+    subsManager: {
+        attach: vi.fn(),
+        detach: vi.fn(),
+        clearAllFromList: vi.fn(),
+    },
+}));
+
+let onAuthChanged: ((state: { authenticated: boolean; reason?: string }) => void) | undefined;
+
+const authApi = {
+    login: vi.fn(),
+    logout: vi.fn(),
+    wipe: vi.fn(),
+    hasCredentials: vi.fn(),
+    getState: vi.fn(),
+    onChanged: vi.fn((callback: (state: { authenticated: boolean; reason?: string }) => void) => {
+        onAuthChanged = callback;
+    }),
+};
+
+const emptyFriendList = { data: { friends: [], outgoingPendingRequests: [], incomingPendingRequests: [] } };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    onAuthChanged = undefined;
+    storedUser.current = undefined;
+    settings.devMode = true;
+    settings.loginAutomatically = true;
+
+    authApi.getState.mockResolvedValue({ authenticated: false });
+    authApi.hasCredentials.mockResolvedValue(false);
+    authApi.logout.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "auth", { value: authApi, writable: true, configurable: true });
+    Object.assign(window.tachyon as any, {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        request: vi.fn().mockResolvedValue(emptyFriendList),
+        onConnected: vi.fn(),
+        onDisconnected: vi.fn(),
+    });
+});
+
+async function loadStore() {
+    vi.resetModules();
+
+    return import("@renderer/store/me.store");
+}
+
+describe("renderer auth projection", () => {
+    it("seeds from the main process rather than assuming signed out", async () => {
+        authApi.getState.mockResolvedValue({ authenticated: true });
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(me.isAuthenticated).toBe(true);
+    });
+
+    it("does not let a stale flag from the cached user win", async () => {
+        storedUser.current = { userId: "42", username: "Cached", isAuthenticated: true };
+        authApi.getState.mockResolvedValue({ authenticated: false });
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(me.username).toBe("Cached");
+        expect(me.isAuthenticated).toBe(false);
+    });
+
+    it("follows a session loss the renderer did not ask for", async () => {
+        authApi.getState.mockResolvedValue({ authenticated: true });
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        onAuthChanged?.({ authenticated: false, reason: "expired" });
+
+        expect(me.isAuthenticated).toBe(false);
+    });
+
+    it("restores without a browser and opens the socket", async () => {
+        authApi.hasCredentials.mockResolvedValue(true);
+        authApi.getState.mockResolvedValue({ authenticated: true });
+
+        const { initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(authApi.login).toHaveBeenCalledWith(false);
+        expect(window.tachyon.connect).toHaveBeenCalled();
+    });
+
+    it("does not touch the session outside dev mode", async () => {
+        settings.devMode = false;
+        authApi.hasCredentials.mockResolvedValue(true);
+
+        const { initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(authApi.login).not.toHaveBeenCalled();
+        expect(window.tachyon.connect).not.toHaveBeenCalled();
+    });
+
+    it("honours the automatic login setting", async () => {
+        settings.loginAutomatically = false;
+        authApi.hasCredentials.mockResolvedValue(true);
+
+        const { initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(authApi.login).not.toHaveBeenCalled();
+    });
+
+    // A valid token plus a refused socket is a ban, or a protocol version the
+    // server no longer speaks. Nothing retries, so the session has to end.
+    it("signs out when the socket refuses the connection", async () => {
+        const session = { authenticated: true };
+        authApi.hasCredentials.mockResolvedValue(true);
+        authApi.getState.mockImplementation(async () => ({ authenticated: session.authenticated }));
+        authApi.logout.mockImplementation(async () => void (session.authenticated = false));
+        (window.tachyon.connect as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("unauthorized_client"));
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(authApi.logout).toHaveBeenCalled();
+        expect(me.isAuthenticated).toBe(false);
+    });
+
+    it("stays offline when the stored credentials are refused", async () => {
+        authApi.hasCredentials.mockResolvedValue(true);
+        authApi.login.mockRejectedValue(new Error("invalid_grant"));
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(me.isAuthenticated).toBe(false);
+        expect(window.tachyon.connect).not.toHaveBeenCalled();
+        expect(me.isInitialized).toBe(true);
+    });
+});

--- a/tests/unit/renderer/auth-projection.spec.ts
+++ b/tests/unit/renderer/auth-projection.spec.ts
@@ -155,6 +155,23 @@ describe("renderer auth projection", () => {
         expect(me.isAuthenticated).toBe(false);
     });
 
+    // Going online has to run through the tachyon store rather than reach past it
+    // to the socket, because that store is the only thing that records a failed
+    // attempt, and its record is what the server status shows.
+    it("records a refused connection where the status can show it", async () => {
+        authApi.hasCredentials.mockResolvedValue(false);
+        authApi.getState.mockResolvedValue({ authenticated: true });
+
+        const { auth, initMeStore } = await loadStore();
+        const { tachyonStore } = await import("@renderer/store/tachyon.store");
+        await initMeStore();
+
+        (window.tachyon.connect as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("unauthorized_client"));
+        await expect(auth.goOnline()).rejects.toThrow();
+
+        expect(tachyonStore.error).toBeDefined();
+    });
+
     it("stays offline when the stored credentials are refused", async () => {
         authApi.hasCredentials.mockResolvedValue(true);
         authApi.login.mockRejectedValue(new Error("invalid_grant"));

--- a/tests/unit/renderer/auth-projection.spec.ts
+++ b/tests/unit/renderer/auth-projection.spec.ts
@@ -109,14 +109,19 @@ describe("renderer auth projection", () => {
     });
 
     it("restores without a browser and opens the socket", async () => {
+        // A cold start has no session yet, so signing in has to happen before
+        // the socket, and without a browser.
+        const session = { authenticated: false };
         authApi.hasCredentials.mockResolvedValue(true);
-        authApi.getState.mockResolvedValue({ authenticated: true });
+        authApi.getState.mockImplementation(async () => ({ authenticated: session.authenticated }));
+        authApi.login.mockImplementation(async () => void (session.authenticated = true));
 
-        const { initMeStore } = await loadStore();
+        const { me, initMeStore } = await loadStore();
         await initMeStore();
 
         expect(authApi.login).toHaveBeenCalledWith(false);
         expect(window.tachyon.connect).toHaveBeenCalled();
+        expect(me.isAuthenticated).toBe(true);
     });
 
     it("does not touch the session outside dev mode", async () => {

--- a/tests/unit/renderer/auth-projection.spec.ts
+++ b/tests/unit/renderer/auth-projection.spec.ts
@@ -139,20 +139,34 @@ describe("renderer auth projection", () => {
         expect(authApi.login).not.toHaveBeenCalled();
     });
 
-    // A valid token plus a refused socket is a ban, or a protocol version the
-    // server no longer speaks. Nothing retries, so the session has to end.
-    it("signs out when the socket refuses the connection", async () => {
-        const session = { authenticated: true };
+    // Only main can tell a rejected refresh token from an unreachable server, and
+    // it already destroys the account in the first case. Signing out from here too
+    // threw away working credentials whenever the network was slower than the app.
+    it("keeps the credentials when the socket refuses the connection", async () => {
         authApi.hasCredentials.mockResolvedValue(true);
-        authApi.getState.mockImplementation(async () => ({ authenticated: session.authenticated }));
-        authApi.logout.mockImplementation(async () => void (session.authenticated = false));
+        authApi.getState.mockResolvedValue({ authenticated: true });
         (window.tachyon.connect as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("unauthorized_client"));
 
         const { me, initMeStore } = await loadStore();
         await initMeStore();
 
-        expect(authApi.logout).toHaveBeenCalled();
-        expect(me.isAuthenticated).toBe(false);
+        expect(authApi.logout).not.toHaveBeenCalled();
+        expect(me.isAuthenticated).toBe(true);
+        expect(me.isInitialized).toBe(true);
+    });
+
+    // A laptop that woke up before its wifi did. Main keeps the session for a
+    // transient failure, so nothing here may throw it away either.
+    it("keeps the credentials when the network is not up yet", async () => {
+        authApi.hasCredentials.mockResolvedValue(true);
+        authApi.getState.mockResolvedValue({ authenticated: true });
+        authApi.login.mockRejectedValue(new Error("network"));
+
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(authApi.logout).not.toHaveBeenCalled();
+        expect(me.isInitialized).toBe(true);
     });
 
     // Going online has to run through the tachyon store rather than reach past it

--- a/tests/unit/renderer/auth-projection.spec.ts
+++ b/tests/unit/renderer/auth-projection.spec.ts
@@ -10,22 +10,6 @@ const settings = vi.hoisted(() => ({ devMode: true, loginAutomatically: true }))
 
 vi.mock("@renderer/store/settings.store", () => ({ settingsStore: settings }));
 
-// The cached user row carries whatever the last run persisted, including a
-// stale session flag, so it must never win over the main process.
-const storedUser = vi.hoisted(() => ({ current: undefined as Record<string, unknown> | undefined }));
-
-vi.mock("@renderer/store/db", () => ({
-    db: {
-        users: {
-            where: () => ({
-                first: async () => storedUser.current,
-                modify: async () => undefined,
-            }),
-            put: async () => undefined,
-        },
-    },
-}));
-
 vi.mock("@renderer/store/users.store", () => ({
     subsManager: {
         attach: vi.fn(),
@@ -39,9 +23,9 @@ let onAuthChanged: ((state: { authenticated: boolean; reason?: string }) => void
 const authApi = {
     login: vi.fn(),
     logout: vi.fn(),
-    wipe: vi.fn(),
     hasCredentials: vi.fn(),
     getState: vi.fn(),
+    getIdentity: vi.fn(),
     onChanged: vi.fn((callback: (state: { authenticated: boolean; reason?: string }) => void) => {
         onAuthChanged = callback;
     }),
@@ -52,13 +36,13 @@ const emptyFriendList = { data: { friends: [], outgoingPendingRequests: [], inco
 beforeEach(() => {
     vi.clearAllMocks();
     onAuthChanged = undefined;
-    storedUser.current = undefined;
     settings.devMode = true;
     settings.loginAutomatically = true;
 
     authApi.getState.mockResolvedValue({ authenticated: false });
     authApi.hasCredentials.mockResolvedValue(false);
     authApi.logout.mockResolvedValue(undefined);
+    authApi.getIdentity.mockResolvedValue(undefined);
 
     Object.defineProperty(window, "auth", { value: authApi, writable: true, configurable: true });
     Object.assign(window.tachyon as any, {
@@ -86,15 +70,25 @@ describe("renderer auth projection", () => {
         expect(me.isAuthenticated).toBe(true);
     });
 
-    it("does not let a stale flag from the cached user win", async () => {
-        storedUser.current = { userId: "42", username: "Cached", isAuthenticated: true };
+    // Identity comes off the durable side, so it is there before any socket is.
+    it("shows who the stored credentials belong to while offline", async () => {
+        authApi.getIdentity.mockResolvedValue({ userId: "42", username: "Cached", displayName: "Cached", countryCode: "" });
         authApi.getState.mockResolvedValue({ authenticated: false });
 
         const { me, initMeStore } = await loadStore();
         await initMeStore();
 
         expect(me.username).toBe("Cached");
+        expect(me.userId).toBe("42");
         expect(me.isAuthenticated).toBe(false);
+    });
+
+    it("falls back to the defaults when nothing is stored yet", async () => {
+        const { me, initMeStore } = await loadStore();
+        await initMeStore();
+
+        expect(me.username).toBe("Player");
+        expect(me.userId).toBe("0");
     });
 
     it("follows a session loss the renderer did not ask for", async () => {

--- a/tests/unit/renderer/connection-intent.spec.ts
+++ b/tests/unit/renderer/connection-intent.spec.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@renderer/router", () => ({ router: { currentRoute: { value: { path: "/" } }, push: vi.fn(), replace: vi.fn() } }));
+
+vi.mock("@renderer/api/notifications", () => ({ notificationsApi: { alert: vi.fn() } }));
+
+const connectHandlers: Array<() => void> = [];
+const disconnectHandlers: Array<() => void> = [];
+const authHandlers: Array<(state: { authenticated: boolean }) => void> = [];
+
+const connect = vi.fn(async () => {});
+const disconnect = vi.fn(async () => {});
+
+Object.assign(window.tachyon, {
+    isConnected: vi.fn(async () => false),
+    connect,
+    disconnect,
+    request: vi.fn(async () => ({ data: {} })),
+    onConnected: (callback: () => void) => void connectHandlers.push(callback),
+    onDisconnected: (callback: () => void) => void disconnectHandlers.push(callback),
+    onBattleStart: vi.fn(),
+});
+
+Object.defineProperty(window, "auth", {
+    value: { onChanged: (callback: (state: { authenticated: boolean }) => void) => void authHandlers.push(callback) },
+    writable: true,
+});
+
+const { tachyonStore, tachyon, initTachyonStore } = await import("@renderer/store/tachyon.store");
+const { me } = await import("@renderer/store/me.store");
+
+const simulateConnect = () => connectHandlers.forEach((handler) => handler());
+const simulateClose = () => disconnectHandlers.forEach((handler) => handler());
+const simulateSessionEnd = () => authHandlers.forEach((handler) => handler({ authenticated: false }));
+
+describe("connection intent", () => {
+    beforeAll(async () => {
+        await initTachyonStore();
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        connect.mockClear();
+        me.isAuthenticated = true;
+        tachyonStore.isConnected = false;
+        tachyonStore.wantsConnection = false;
+    });
+
+    afterEach(() => {
+        tachyon.goOffline();
+        vi.useRealTimers();
+    });
+
+    it("takes an open connection as wanting to be online", () => {
+        simulateConnect();
+
+        expect(tachyonStore.wantsConnection).toBe(true);
+    });
+
+    it("retries when a wanted connection drops", () => {
+        simulateConnect();
+        simulateClose();
+
+        expect(tachyonStore.reconnectInterval).toBeDefined();
+
+        vi.advanceTimersByTime(10000);
+        expect(connect).toHaveBeenCalled();
+    });
+
+    it("stays quiet when the user asked to go offline", async () => {
+        simulateConnect();
+        await tachyon.goOffline();
+        simulateClose();
+
+        expect(tachyonStore.reconnectInterval).toBeUndefined();
+    });
+
+    // Logout drops the socket without going through disconnect(), so the intent
+    // has to be cleared by the session ending rather than by that one call site.
+    it("stays quiet when the session ends before the socket closes", () => {
+        simulateConnect();
+
+        simulateSessionEnd();
+        simulateClose();
+
+        expect(tachyonStore.wantsConnection).toBe(false);
+        expect(tachyonStore.reconnectInterval).toBeUndefined();
+    });
+
+    it("gives up on a retry in progress when the session ends", () => {
+        simulateConnect();
+        simulateClose();
+        expect(tachyonStore.reconnectInterval).toBeDefined();
+
+        simulateSessionEnd();
+
+        expect(tachyonStore.reconnectInterval).toBeUndefined();
+
+        vi.advanceTimersByTime(30000);
+        expect(connect).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/renderer/server-status.spec.ts
+++ b/tests/unit/renderer/server-status.spec.ts
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import ServerStatus from "@renderer/components/navbar/ServerStatus.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stubs = vi.hoisted(() => ({
+    tachyonStore: {} as {
+        isConnected: boolean;
+        wantsConnection: boolean;
+        error?: string;
+        reconnectInterval?: NodeJS.Timeout;
+        serverStats?: { userCount: number };
+    },
+    me: { isAuthenticated: true },
+    goOnline: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    openLogInConfirmation: vi.fn(),
+}));
+
+vi.mock("@renderer/i18n", () => ({ useTypedI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("vue-router", () => ({ useRouter: () => ({ currentRoute: { value: { path: "/play" } } }) }));
+vi.mock("@renderer/composables/useLogInConfirmation", () => ({
+    useLogInConfirmation: () => ({ openLogInConfirmation: stubs.openLogInConfirmation }),
+}));
+vi.mock("@renderer/store/tachyon.store", () => ({
+    tachyonStore: stubs.tachyonStore,
+    tachyon: { goOffline: stubs.disconnect },
+}));
+vi.mock("@renderer/store/me.store", () => ({
+    me: stubs.me,
+    auth: { goOnline: stubs.goOnline },
+}));
+
+const RETRYING = 1 as unknown as NodeJS.Timeout;
+
+// Modal teleports to #wrapper, which does not exist here, and the confirmation
+// body is the thing under test.
+const ModalStub = {
+    name: "Modal",
+    props: ["modelValue", "title"],
+    template: `<div class="modal"><div class="modal-title">{{ title }}</div><slot /></div>`,
+};
+
+function render(state: Partial<typeof stubs.tachyonStore> & { authenticated?: boolean } = {}) {
+    const { authenticated = true, ...store } = state;
+    Object.assign(stubs.tachyonStore, {
+        isConnected: false,
+        wantsConnection: false,
+        error: undefined,
+        reconnectInterval: undefined,
+        serverStats: undefined,
+        ...store,
+    });
+    stubs.me.isAuthenticated = authenticated;
+
+    return mount(ServerStatus, {
+        global: {
+            stubs: { Modal: ModalStub },
+            directives: { "click-away": {} },
+        },
+    });
+}
+
+const label = (wrapper: ReturnType<typeof render>) => wrapper.find("button").text();
+// Button puts state classes on its Control wrapper, so that is the element worth
+// asserting against. The clickable button is nested inside it.
+const menuEntries = (wrapper: ReturnType<typeof render>) => wrapper.findAll(".status-menu .control");
+
+async function openMenu(wrapper: ReturnType<typeof render>) {
+    await wrapper.find("button").trigger("click");
+
+    return menuEntries(wrapper);
+}
+
+const choose = (entry: ReturnType<typeof menuEntries>[number]) => entry.find("button").trigger("click");
+
+beforeEach(() => {
+    stubs.goOnline.mockClear();
+    stubs.disconnect.mockClear();
+    stubs.openLogInConfirmation.mockClear();
+});
+
+describe("ServerStatus label", () => {
+    it("reports offline when signed out", () => {
+        expect(label(render({ authenticated: false }))).toContain("lobby.navbar.serverStatus.offline");
+    });
+
+    it("reports the player count while connected", () => {
+        const wrapper = render({ isConnected: true, wantsConnection: true, serverStats: { userCount: 42 } });
+
+        expect(label(wrapper)).toContain("42");
+        expect(label(wrapper)).toContain("lobby.navbar.serverStatus.playersOnline");
+    });
+
+    // Every failed attempt sets an error, so reading the error first reported a
+    // fault for the whole of a retry loop that was working as intended.
+    it("reports reconnecting while retries are running, even with an error set", () => {
+        const wrapper = render({ wantsConnection: true, reconnectInterval: RETRYING, error: "Error" });
+
+        expect(label(wrapper)).toContain("lobby.navbar.serverStatus.reconnecting");
+    });
+
+    it("reports offline when signed in with no socket and nothing being retried", () => {
+        expect(label(render())).toContain("lobby.navbar.serverStatus.offline");
+    });
+});
+
+describe("ServerStatus menu", () => {
+    it("prompts for sign in instead of opening when signed out", async () => {
+        const wrapper = render({ authenticated: false });
+
+        await wrapper.find("button").trigger("click");
+
+        expect(stubs.openLogInConfirmation).toHaveBeenCalled();
+        expect(menuEntries(wrapper)).toHaveLength(0);
+    });
+
+    it("marks Online as current while connected", async () => {
+        const entries = await openMenu(render({ isConnected: true, wantsConnection: true }));
+
+        expect(entries[0].classes()).toContain("current");
+        expect(entries[2].classes()).not.toContain("current");
+    });
+
+    // The user did not ask for the drop, so a retry in progress is still Online.
+    // Deriving this from the socket put them on Offline while the button above
+    // the menu said Reconnecting.
+    it("keeps Online as current while retrying", async () => {
+        const entries = await openMenu(render({ wantsConnection: true, reconnectInterval: RETRYING }));
+
+        expect(entries[0].classes()).toContain("current");
+        expect(entries[2].classes()).not.toContain("current");
+    });
+
+    it("marks Offline as current once the user has gone offline", async () => {
+        const entries = await openMenu(render({ wantsConnection: false }));
+
+        expect(entries[2].classes()).toContain("current");
+        expect(entries[0].classes()).not.toContain("current");
+    });
+
+    // Button turns disabled into a class on its Control wrapper rather than an
+    // attribute on the inner button, and that class is what stops the clicks.
+    it("leaves Busy permanently unavailable", async () => {
+        const entries = await openMenu(render({ isConnected: true, wantsConnection: true }));
+
+        expect(entries[1].classes()).toContain("disabled");
+    });
+});
+
+describe("ServerStatus actions", () => {
+    it("connects without confirmation when picking Online", async () => {
+        const entries = await openMenu(render());
+
+        await choose(entries[0]);
+
+        expect(stubs.goOnline).toHaveBeenCalledOnce();
+    });
+
+    it("does nothing when picking Online while already connected", async () => {
+        const entries = await openMenu(render({ isConnected: true, wantsConnection: true }));
+
+        await choose(entries[0]);
+
+        expect(stubs.goOnline).not.toHaveBeenCalled();
+    });
+
+    // Leaving is disruptive, so it confirms rather than acting on the click.
+    it("confirms before disconnecting", async () => {
+        const wrapper = render({ isConnected: true, wantsConnection: true });
+        const entries = await openMenu(wrapper);
+
+        await choose(entries[2]);
+
+        expect(wrapper.find(".modal-title").text()).toBe("lobby.navbar.serverStatus.disconnectTitle");
+        expect(stubs.disconnect).not.toHaveBeenCalled();
+    });
+
+    it("disconnects once the confirmation is accepted", async () => {
+        const wrapper = render({ isConnected: true, wantsConnection: true });
+        const entries = await openMenu(wrapper);
+        await choose(entries[2]);
+
+        await wrapper.findAll(".modal button").at(1)!.trigger("click");
+
+        expect(stubs.disconnect).toHaveBeenCalledOnce();
+    });
+
+    it("offers to stop retrying rather than to disconnect while reconnecting", async () => {
+        const wrapper = render({ wantsConnection: true, reconnectInterval: RETRYING });
+        const entries = await openMenu(wrapper);
+
+        await choose(entries[2]);
+
+        expect(wrapper.find(".modal-title").text()).toBe("lobby.navbar.serverStatus.stopReconnectingTitle");
+    });
+
+    // The connection can change while the modal sits there, and the user has to
+    // get the action they were shown rather than one chosen when they confirm.
+    it("runs the action it offered, not the one the current state implies", async () => {
+        const wrapper = render({ isConnected: true, wantsConnection: true });
+        const entries = await openMenu(wrapper);
+        await choose(entries[2]);
+
+        stubs.tachyonStore.isConnected = false;
+        stubs.tachyonStore.wantsConnection = false;
+        await wrapper.vm.$nextTick();
+        await wrapper.findAll(".modal button").at(1)!.trigger("click");
+
+        expect(stubs.disconnect).toHaveBeenCalledOnce();
+        expect(stubs.goOnline).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/renderer/server-switch.spec.ts
+++ b/tests/unit/renderer/server-switch.spec.ts
@@ -4,27 +4,41 @@
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
+import { flushPromises } from "@vue/test-utils";
 
 vi.mock("@renderer/store/db", () => ({
     db: { users: { where: () => ({ first: async () => undefined, modify: async () => undefined }), put: vi.fn() } },
 }));
 
 const disconnect = vi.fn(async () => {});
-const wipe = vi.fn(async () => {});
 const onConnected = vi.fn(async () => {});
+
+const session = { authenticated: true };
+const logout = vi.fn(async () => void (session.authenticated = false));
 
 Object.assign(window.tachyon, { disconnect, onConnected });
 Object.defineProperty(window, "auth", {
-    value: { wipe, hasCredentials: vi.fn(async () => false), login: vi.fn(async () => {}), logout: vi.fn(async () => {}) },
+    value: {
+        logout,
+        getState: vi.fn(async () => ({ authenticated: session.authenticated })),
+        getIdentity: vi.fn(async () => undefined),
+        hasCredentials: vi.fn(async () => false),
+        login: vi.fn(async () => {}),
+        onChanged: vi.fn(),
+    },
     writable: true,
 });
 
 const { me, initMeStore } = await import("@renderer/store/me.store");
 const { settingsStore } = await import("@renderer/store/settings.store");
+const { tachyonStore } = await import("@renderer/store/tachyon.store");
 
+// The watcher does not await the switch, and the session state it ends with is
+// read back from main at the end of that chain rather than assigned up front.
 async function changeServerTo(server: string) {
     settingsStore.lobbyServer = server;
     await nextTick();
+    await flushPromises();
 }
 
 describe("switching the active server", () => {
@@ -36,7 +50,8 @@ describe("switching the active server", () => {
 
     beforeEach(async () => {
         disconnect.mockClear();
-        wipe.mockClear();
+        logout.mockClear();
+        session.authenticated = true;
         settingsStore.isInitialized = false;
         settingsStore.lobbyServer = "wss://server4.beyondallreason.info";
         await nextTick();
@@ -51,7 +66,7 @@ describe("switching the active server", () => {
 
         await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
 
-        expect(wipe).not.toHaveBeenCalled();
+        expect(logout).not.toHaveBeenCalled();
         expect(disconnect).not.toHaveBeenCalled();
         expect(me.isAuthenticated).toBe(true);
     });
@@ -60,6 +75,7 @@ describe("switching the active server", () => {
         beforeEach(() => {
             settingsStore.isInitialized = true;
             me.isAuthenticated = true;
+            tachyonStore.wantsConnection = true;
         });
 
         // The same setting picks the authorization server, so the tokens we hold
@@ -67,7 +83,7 @@ describe("switching the active server", () => {
         it("throws the credentials away rather than carrying them over", async () => {
             await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
 
-            expect(wipe).toHaveBeenCalledOnce();
+            expect(logout).toHaveBeenCalledOnce();
             expect(me.isAuthenticated).toBe(false);
         });
 
@@ -77,23 +93,23 @@ describe("switching the active server", () => {
             expect(disconnect).toHaveBeenCalledOnce();
         });
 
-        // A drop while we still look authenticated gets a reconnect timer, which
-        // then keeps firing against credentials that are already gone.
-        it("has given up the session before the connection closes", async () => {
-            let authenticatedWhenClosing: boolean | undefined;
+        // A close that still looks wanted gets a reconnect timer, which would then
+        // keep firing at credentials that are already gone.
+        it("has given up wanting a connection before the socket closes", async () => {
+            let wantedWhenClosing: boolean | undefined;
             disconnect.mockImplementationOnce(async () => {
-                authenticatedWhenClosing = me.isAuthenticated;
+                wantedWhenClosing = tachyonStore.wantsConnection;
             });
 
             await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
 
-            expect(authenticatedWhenClosing).toBe(false);
+            expect(wantedWhenClosing).toBe(false);
         });
 
         it("does nothing when the same server is picked again", async () => {
             await changeServerTo("wss://server4.beyondallreason.info");
 
-            expect(wipe).not.toHaveBeenCalled();
+            expect(logout).not.toHaveBeenCalled();
             expect(disconnect).not.toHaveBeenCalled();
         });
     });

--- a/tests/unit/renderer/store-going-offline.spec.ts
+++ b/tests/unit/renderer/store-going-offline.spec.ts
@@ -21,6 +21,8 @@ Object.assign(window.tachyon, {
     onConnected: (callback: () => void) => void connectHandlers.push(callback),
 });
 
+Object.defineProperty(window, "auth", { value: { onChanged: vi.fn() }, writable: true });
+
 const { matchmakingStore, MatchmakingStatus, initializeMatchmakingStore } = await import("@renderer/store/matchmaking.store");
 const { partyStore, party, PlayersPartyState, initPartyStore } = await import("@renderer/store/party.store");
 const { lobbyStore, initLobbyStore } = await import("@renderer/store/lobby.store");

--- a/tests/unit/shared/preload-api-context-bridge.spec.ts
+++ b/tests/unit/shared/preload-api-context-bridge.spec.ts
@@ -157,13 +157,11 @@ describe("Preload API Context Bridge", () => {
 
         mockWindow.auth.login(false);
         mockWindow.auth.logout();
-        mockWindow.auth.wipe();
         mockWindow.auth.hasCredentials();
         mockWindow.auth.getState();
 
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:login", false);
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:logout");
-        expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:wipe");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:hasCredentials");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:state");
     });

--- a/tests/unit/shared/preload-api-context-bridge.spec.ts
+++ b/tests/unit/shared/preload-api-context-bridge.spec.ts
@@ -159,8 +159,10 @@ describe("Preload API Context Bridge", () => {
         mockWindow.auth.logout();
         mockWindow.auth.hasCredentials();
         mockWindow.auth.getState();
+        mockWindow.auth.getIdentity();
 
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:login", false);
+        expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:identity");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:logout");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:hasCredentials");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:state");

--- a/tests/unit/shared/preload-api-context-bridge.spec.ts
+++ b/tests/unit/shared/preload-api-context-bridge.spec.ts
@@ -155,15 +155,17 @@ describe("Preload API Context Bridge", () => {
     it("should expose auth API", async () => {
         await import("@preload/preload");
 
-        mockWindow.auth.login();
+        mockWindow.auth.login(false);
         mockWindow.auth.logout();
         mockWindow.auth.wipe();
         mockWindow.auth.hasCredentials();
+        mockWindow.auth.getState();
 
-        expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:login");
+        expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:login", false);
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:logout");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:wipe");
         expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:hasCredentials");
+        expect(mockIpcRenderer.invoke).toHaveBeenCalledWith("auth:state");
     });
 
     it("should expose engine API", async () => {


### PR DESCRIPTION
Auth state was spread across a few files and the renderer kept its own copy of whether you were logged in, so a refresh failing in the background left the UI still saying you were online. One place tracks it now and the renderer reads from that. A temporary server hiccup no longer signs you out and sends you back through the browser, and sign-in details no longer reach the log files, which is how #385 turned up in the first place.

Logout means logout now. It destroys the stored account rather than quietly keeping the refresh token, which is what "Change account" existed to work around, so that's gone too. Signing in on launch is still its own setting and logging out leaves it alone.

Being signed in without being connected is a normal thing to be, so going online and going offline are things you can do on purpose, from the server status. Going offline asks first because it drops you out of anything you're in. Going online doesn't, since there's nothing to lose by it.

Your name and id sit next to the credentials now rather than in the renderer's browser-side storage. That storage is a cache as far as the browser is concerned, so it can be thrown out when disk gets tight, it's one click to clear from devtools, and a change to the database layout can drop it, while the credentials it describes are in a plain file that survives all three. When it went you were left signed in with no name to show.

Most of the size is collecting auth logic that was scattered across main, the renderer and a timer in the oauth code into one place.

Rebased onto #657 and still draft until that lands, so the diff includes it.

AI disclosure: written with assistance from Claude Code.
