### PR TITLE
Tachyon version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "primeicons": "^6.0.1",
                 "primevue": "3.23.0",
                 "sdfz-demo-parser": "^5.15.0",
-                "tachyon-protocol": "^1.22.0",
+                "tachyon-protocol": "^1.23.0",
                 "vue-i18n": "^11.1.11",
                 "vue-router": "^4.5.1",
                 "ws": "^8.18.3"
@@ -12232,9 +12232,9 @@
             "license": "MIT"
         },
         "node_modules/tachyon-protocol": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/tachyon-protocol/-/tachyon-protocol-1.22.0.tgz",
-            "integrity": "sha512-SkrJr/1Yp3qbyRXqUUQUp4l/pm+Z+COtiovxidg9XoW2keFHfKNMy8doz78yRRe7Gv/xEXS9gDO7NDWHoqq01w==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/tachyon-protocol/-/tachyon-protocol-1.23.0.tgz",
+            "integrity": "sha512-7Ji9ULgIv03p1NEQaJZvNeWCarTiR99Jt53gow53u+f+G8jXWIn8XzYcckm9m02D0va768J0t9ramChCBEBJ9g==",
             "license": "ISC",
             "dependencies": {
                 "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "primeicons": "^6.0.1",
         "primevue": "3.23.0",
         "sdfz-demo-parser": "^5.15.0",
-        "tachyon-protocol": "^1.22.0",
+        "tachyon-protocol": "^1.23.0",
         "vue-i18n": "^11.1.11",
         "vue-router": "^4.5.1",
         "ws": "^8.18.3"

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -6,7 +6,7 @@ import { accountService } from "@main/services/account.service";
 import { TachyonClient, TachyonClientRequestHandlers } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
-import { BattleStartRequestData } from "tachyon-protocol/types";
+import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("tachyon-service");
@@ -20,6 +20,14 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
             webContents.send("tachyon:battleStart", springString);
             return {
                 status: "success",
+            };
+        },
+        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
+            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
+            return {
+                status: "failed",
+                reason: "command_unimplemented",
+                details: "This client does not yet check assets, and instead auto-fails.",
             };
         },
     };


### PR DESCRIPTION
Tachyon Protocol bump to 1.23.0

Added required `checkAssets` response for type-safety completion; however logic only auto-fails. At the moment, the dev server does not send this request.