### PR TITLE
Refactor Tachyon server-to-client request handlers

### DIFF
--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -6,7 +6,7 @@ import { accountService } from "@main/services/account.service";
 import { TachyonClient, TachyonClientRequestHandlers } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
-import { BattleStartRequestData } from "tachyon-protocol/types";
+import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("tachyon-service");
@@ -20,6 +20,16 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
             webContents.send("tachyon:battleStart", springString);
             return {
                 status: "success",
+            };
+        },
+        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
+            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
+            // Seding Failed response just for now to get the request/response working correctly at a base level
+            // Note to self; rebuild tachyon with the latest checkAssets request and then relink
+            return {
+                status: "failed",
+                reason: "command_unimplemented",
+                details: "This client does not yet check assets, and instead auto-fails.",
             };
         },
     };

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -8,43 +8,11 @@ import { TachyonClient } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
 import { BarIpcWebContents } from "@main/typed-ipc";
-import { gameContentAPI } from "@main/content/game/game-content";
-import { mapContentAPI } from "@main/content/maps/map-content";
-import { engineContentAPI } from "@main/content/engine/engine-content";
 
 const log = logger("tachyon-service");
 
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     const requestHandlers = createTachyonRequestHandlers(webContents);
-    const requestHandlers: TachyonClientRequestHandlers = {
-        "battle/start": async (data: BattleStartRequestData) => {
-            log.info(`Received battle start request: ${JSON.stringify(data)}`);
-            const itemsRequired =
-                !gameContentAPI.isVersionInstalled(data.game.springName) || !mapContentAPI.isVersionInstalled(data.map.springName) || !engineContentAPI.isVersionInstalled(data.engine.version);
-            if (itemsRequired) {
-                webContents.send("notifications:showAlert", {
-                    text: `Unable to join match, required assets are missing.`,
-                    severity: "error",
-                });
-                return { status: "failed", reason: "internal_error" };
-            } else {
-                const { ip, port, username, password } = data;
-                const springString = `spring://${username}:${password}@${ip}:${port}`;
-                webContents.send("tachyon:battleStart", springString, data);
-                return {
-                    status: "success",
-                };
-            }
-        },
-        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
-            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
-            return {
-                status: "failed",
-                reason: "command_unimplemented",
-                details: "This client does not yet check assets, and instead auto-fails.",
-            };
-        },
-    };
     const tachyonClient = new TachyonClient(requestHandlers);
 
     tachyonClient.onSocketOpen.add(() => {

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -3,35 +3,16 @@
 // SPDX-License-Identifier: MIT
 
 import { accountService } from "@main/services/account.service";
-import { TachyonClient, TachyonClientRequestHandlers } from "@main/tachyon/tachyon-client";
+import { createTachyonRequestHandlers } from "@main/tachyon/tachyon.handlers";
+import { TachyonClient } from "@main/tachyon/tachyon-client";
 import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
-import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("tachyon-service");
 
-// It would be good to have functions referenced here but the overall logic elsewhere to avoid clutter as this grows.
 function registerIpcHandlers(webContents: BarIpcWebContents) {
-    const requestHandlers: TachyonClientRequestHandlers = {
-        "battle/start": async (data: BattleStartRequestData) => {
-            log.info(`Received battle start request: ${JSON.stringify(data)}`);
-            const { ip, port, username, password } = data;
-            const springString = `spring://${username}:${password}@${ip}:${port}`;
-            webContents.send("tachyon:battleStart", springString);
-            return {
-                status: "success",
-            };
-        },
-        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
-            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
-            return {
-                status: "failed",
-                reason: "command_unimplemented",
-                details: "This client does not yet check assets, and instead auto-fails.",
-            };
-        },
-    };
+    const requestHandlers = createTachyonRequestHandlers(webContents);
     const tachyonClient = new TachyonClient(requestHandlers);
 
     tachyonClient.onSocketOpen.add(() => {

--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -11,6 +11,7 @@ import { BarIpcWebContents } from "@main/typed-ipc";
 
 const log = logger("tachyon-service");
 
+// It would be good to have functions referenced here but the overall logic elsewhere to avoid clutter as this grows.
 function registerIpcHandlers(webContents: BarIpcWebContents) {
     const requestHandlers: TachyonClientRequestHandlers = {
         "battle/start": async (data: BattleStartRequestData) => {
@@ -22,10 +23,11 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
                 status: "success",
             };
         },
+        // Note; requires npm link on tachyon-protocol to work correctly, as the types are not yet published to npm.
         "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
             log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
-            // Seding Failed response just for now to get the request/response working correctly at a base level
-            // Note to self; rebuild tachyon with the latest checkAssets request and then relink
+            // Sending Failed response just for now to get the request/response working correctly at a base level
+            // Correct behavior will be to check the assets and return a success or failed response based on that check
             return {
                 status: "failed",
                 reason: "command_unimplemented",

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -23,8 +23,6 @@ export type TachyonClientRequestHandlers = {
     [CommandId in ServerToUserRequestCommandId]: (data: GetCommandData<ServerToUserRequest<CommandId>>) => Promise<UserToServerResponseBody<CommandId>>;
 };
 
-export type PartialTachyonClientRequestHandlers = Partial<TachyonClientRequestHandlers>;
-
 class InternalError extends Error {
     constructor(message: string) {
         super(message);
@@ -48,10 +46,10 @@ export class TachyonClient {
     public onSocketClose: Signal<void> = new Signal();
     public onEvent: Signal<TachyonEvent> = new Signal();
 
-    private requestHandlers: PartialTachyonClientRequestHandlers;
+    private requestHandlers: TachyonClientRequestHandlers;
     private responseHandlers: Map<string, (response: TachyonResponse | { status: "socket_closed" }) => void> = new Map();
 
-    constructor(requestHandlers: PartialTachyonClientRequestHandlers) {
+    constructor(requestHandlers: TachyonClientRequestHandlers) {
         this.requestHandlers = requestHandlers;
     }
 

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -14,11 +14,16 @@ import { MessageEvent, WebSocket } from "ws";
 
 const log = logger("tachyon-client");
 
+type ServerToUserRequestCommandId = GetCommandIds<"server", "user", "request">;
+type ServerToUserRequest<C extends ServerToUserRequestCommandId = ServerToUserRequestCommandId> = GetCommands<"server", "user", "request", C>;
+type UserToServerResponseBody<C extends ServerToUserRequestCommandId = ServerToUserRequestCommandId> = Omit<GetCommands<"user", "server", "response", C>, "type" | "commandId" | "messageId">;
+type AnyUserToServerResponseBody = UserToServerResponseBody<ServerToUserRequestCommandId>;
+
 export type TachyonClientRequestHandlers = {
-    [CommandId in GetCommandIds<"server", "user", "request">]: (
-        data: GetCommandData<GetCommands<"server", "user", "request", CommandId>>
-    ) => Promise<Omit<GetCommands<"user", "server", "response", CommandId>, "type" | "commandId" | "messageId">>;
+    [CommandId in ServerToUserRequestCommandId]: (data: GetCommandData<ServerToUserRequest<CommandId>>) => Promise<UserToServerResponseBody<CommandId>>;
 };
+
+export type PartialTachyonClientRequestHandlers = Partial<TachyonClientRequestHandlers>;
 
 export class TachyonClient {
     public socket?: WebSocket;
@@ -27,10 +32,10 @@ export class TachyonClient {
     public onSocketClose: Signal<void> = new Signal();
     public onEvent: Signal<TachyonEvent> = new Signal();
 
-    private requestHandlers: TachyonClientRequestHandlers;
+    private requestHandlers: PartialTachyonClientRequestHandlers;
     private responseHandlers: Map<string, (response: TachyonResponse | { status: "socket_closed" }) => void> = new Map();
 
-    constructor(requestHandlers: TachyonClientRequestHandlers) {
+    constructor(requestHandlers: PartialTachyonClientRequestHandlers) {
         this.requestHandlers = requestHandlers;
     }
 
@@ -178,7 +183,7 @@ export class TachyonClient {
             throw new Error(`Message does not match expected command structure`);
         }
         if (obj.type === "request") {
-            this.handleRequest(obj);
+            this.handleRequest(obj as ServerToUserRequest);
         } else if (obj.type === "response") {
             this.handleResponse(obj);
         } else if (obj.type === "event") {
@@ -189,16 +194,25 @@ export class TachyonClient {
     }
 
     private async handleRequest(command: TachyonRequest) {
-        const handler = this.requestHandlers[command.commandId as keyof typeof this.requestHandlers] as unknown as (
-            data?: unknown
-        ) => Promise<Omit<TachyonResponse, "type" | "commandId" | "messageId">>;
+        const commandId = command.commandId as ServerToUserRequestCommandId;
+        const handler = this.requestHandlers[commandId] as ((data?: unknown) => Promise<AnyUserToServerResponseBody>) | undefined;
+        const requestData = "data" in command ? command.data : undefined;
+
+        let handlerResponse: AnyUserToServerResponseBody;
         if (!handler) {
-            throw new Error(`No response handler found for: ${command.commandId}`);
+            log.warn(`No response handler found for: ${commandId}`);
+            handlerResponse = {
+                status: "failed",
+                reason: "command_unimplemented",
+                details: `No response handler found for: ${commandId}`,
+            } as AnyUserToServerResponseBody;
+        } else {
+            handlerResponse = await handler(requestData);
         }
-        const handlerResponse = await handler("data" in command ? command.data : undefined);
+
         const response = {
             type: "response",
-            commandId: command.commandId,
+            commandId,
             messageId: command.messageId,
             ...handlerResponse,
         } as TachyonResponse;

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -231,7 +231,16 @@ export class TachyonClient {
                 details: `No response handler found for: ${commandId}`,
             } as AnyUserToServerResponseBody;
         } else {
-            handlerResponse = await handler(requestData);
+            try {
+                handlerResponse = await handler(requestData);
+            } catch (error) {
+                log.error(`Error handling request for request ${commandId}: ${error}`);
+                handlerResponse = {
+                    status: "failed",
+                    reason: "internal_error",
+                    details: error instanceof Error ? error.message : "Unknown error occurred",
+                } as AnyUserToServerResponseBody;
+            }
         }
 
         const response = {

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -16,7 +16,8 @@ const log = logger("tachyon-client");
 
 type ServerToUserRequestCommandId = GetCommandIds<"server", "user", "request">;
 type ServerToUserRequest<C extends ServerToUserRequestCommandId = ServerToUserRequestCommandId> = GetCommands<"server", "user", "request", C>;
-type UserToServerResponseBody<C extends ServerToUserRequestCommandId = ServerToUserRequestCommandId> = Omit<GetCommands<"user", "server", "response", C>, "type" | "commandId" | "messageId">;
+type StripEnvelope<T> = T extends object ? Omit<T, "type" | "commandId" | "messageId"> : never;
+type UserToServerResponseBody<C extends ServerToUserRequestCommandId = ServerToUserRequestCommandId> = StripEnvelope<GetCommands<"user", "server", "response", C>>;
 type AnyUserToServerResponseBody = UserToServerResponseBody<ServerToUserRequestCommandId>;
 
 export type TachyonClientRequestHandlers = {

--- a/src/main/tachyon/tachyon-client.ts
+++ b/src/main/tachyon/tachyon-client.ts
@@ -25,6 +25,22 @@ export type TachyonClientRequestHandlers = {
 
 export type PartialTachyonClientRequestHandlers = Partial<TachyonClientRequestHandlers>;
 
+class InternalError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "InternalError";
+        Object.setPrototypeOf(this, InternalError.prototype);
+    }
+}
+
+class UnimplementedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UnimplementedError";
+        Object.setPrototypeOf(this, UnimplementedError.prototype);
+    }
+}
+
 export class TachyonClient {
     public socket?: WebSocket;
 
@@ -130,9 +146,13 @@ export class TachyonClient {
         if (data) {
             Object.assign(request, { data });
         }
-        validateCommand(request);
-        this.socket.send(JSON.stringify(request));
-
+        try {
+            validateMessage(request, "command");
+            this.socket.send(JSON.stringify(request));
+        } catch (error) {
+            log.error(`Failed to send request ${commandId}: ${error}`);
+            throw error;
+        }
         return new Promise((resolve, reject) => {
             this.responseHandlers.set(messageId, (response: TachyonResponse | { status: "socket_closed" }) => {
                 if (response.status === "socket_closed") {
@@ -173,8 +193,13 @@ export class TachyonClient {
         if (!this.socket) {
             throw new Error("Not connected to server");
         }
-        validateCommand(event);
-        this.socket.send(JSON.stringify(event));
+        try {
+            validateMessage(event, "command");
+            this.socket.send(JSON.stringify(event));
+        } catch (error) {
+            log.error(`Failed to send event ${event.commandId}: ${error}`);
+            throw error;
+        }
     }
 
     protected handleMessage(message: MessageEvent) {
@@ -216,8 +241,35 @@ export class TachyonClient {
             messageId: command.messageId,
             ...handlerResponse,
         } as TachyonResponse;
-        validateCommand(response);
-        this.socket?.send(JSON.stringify(response));
+
+        try {
+            validateMessage(response, "response");
+            this.socket?.send(JSON.stringify(response));
+        } catch (err) {
+            let reason = "internal_error";
+            let details = err instanceof Error ? err.message : "Unknown error occurred";
+
+            if (err instanceof UnimplementedError) {
+                reason = "command_unimplemented";
+            } else if (err instanceof InternalError) {
+                reason = "internal_error";
+            } else {
+                log.error("Unexpected error during response handling:", err);
+                reason = "internal_error";
+                details = "An unexpected validation lifecycle error occurred.";
+            }
+
+            this.socket?.send(
+                JSON.stringify({
+                    type: "response",
+                    commandId,
+                    messageId: command.messageId,
+                    status: "failed",
+                    reason,
+                    details,
+                } as TachyonResponse)
+            );
+        }
     }
 
     private async handleResponse(response: TachyonResponse) {
@@ -252,17 +304,21 @@ export class TachyonClient {
     }
 }
 
-function validateCommand(command: TachyonCommand) {
-    const commandId = command.commandId;
-    const validatorId = `${commandId}/${command.type}`.replaceAll("/", "_") as Exclude<keyof typeof validators, "validator">;
+function validateMessage(message: TachyonCommand, context: "command" | "response") {
+    const commandId = message.commandId;
+
+    const validatorId = `${commandId}/${message.type}`.replaceAll("/", "_") as Exclude<keyof typeof validators, "validator">;
+
     const validator = validators[validatorId];
+
     if (!validator) {
-        throw new Error(`No validator found with id: ${validatorId}`);
+        throw new UnimplementedError(`No validator found with id: ${validatorId}`);
     }
-    const isValid = validator(command);
+
+    const isValid = validator(message);
     if (!isValid) {
         log.error(validator.errors);
-        throw new Error(`Command validation failed for: ${commandId}`);
+        throw new InternalError(`${context === "command" ? "Command" : "Response"} validation failed for: ${commandId}`);
     }
 }
 

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -4,7 +4,7 @@
 
 import { BarIpcWebContents } from "@main/typed-ipc";
 import { logger } from "@main/utils/logger";
-import { PartialTachyonClientRequestHandlers, TachyonClientRequestHandlers } from "./tachyon-client";
+import { TachyonClientRequestHandlers } from "./tachyon-client";
 import { GetCommandData, GetCommandIds, GetCommands } from "tachyon-protocol";
 import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { gameContentAPI } from "@main/content/game/game-content";
@@ -32,11 +32,11 @@ function defineTachyonRequestHandler<C extends ServerToUserRequestId, R extends 
     } as unknown as Pick<TachyonClientRequestHandlers, C>;
 }
 
-export function createTachyonRequestHandlers(webContents: BarIpcWebContents): PartialTachyonClientRequestHandlers {
+export function createTachyonRequestHandlers(webContents: BarIpcWebContents): TachyonClientRequestHandlers {
     return {
         ...createBattleHandlers(webContents),
         ...createMatchmakingHandlers(),
-    };
+    } satisfies TachyonClientRequestHandlers;
 }
 
 function createBattleHandlers(webContents: BarIpcWebContents) {
@@ -53,7 +53,7 @@ function createBattleHandlers(webContents: BarIpcWebContents) {
                 };
             })
         ),
-    } satisfies PartialTachyonClientRequestHandlers;
+    } satisfies Partial<TachyonClientRequestHandlers>;
 }
 
 function createMatchmakingHandlers() {
@@ -76,5 +76,5 @@ function createMatchmakingHandlers() {
                 };
             })
         ),
-    } satisfies PartialTachyonClientRequestHandlers;
+    } satisfies Partial<TachyonClientRequestHandlers>;
 }

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -5,7 +5,10 @@
 import { BarIpcWebContents } from "@main/typed-ipc";
 import { logger } from "@main/utils/logger";
 import { TachyonClientRequestHandlers } from "./tachyon-client";
-import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
+import { BattleStartRequestData, MatchmakingCheckAssetsOkResponseData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
+import { gameContentAPI } from "@main/content/game/game-content";
+import { mapContentAPI } from "@main/content/maps/map-content";
+import { engineContentAPI } from "@main/content/engine/engine-content";
 
 const log = logger("tachyon-handlers");
 
@@ -34,10 +37,30 @@ function createMatchmakingHandlers(): Pick<TachyonClientRequestHandlers, "matchm
     return {
         "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
             log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
+            let itemsRequired: boolean = false;
+            if (!gameContentAPI.isVersionInstalled(data.game)) {
+                itemsRequired = true;
+            }
+            for (const map of data.maps) {
+                if (!mapContentAPI.isVersionInstalled(map)) {
+                    itemsRequired = true;
+                    break;
+                }
+            }
+            for (const engine of data.engines) {
+                if (!engineContentAPI.isVersionInstalled(engine)) {
+                    itemsRequired = true;
+                    break;
+                }
+            }
+            // Technically we can return "downloading" if any assets are missing, but for now we just return "missing" or "complete
+            const result: MatchmakingCheckAssetsOkResponseData = {
+                assetStatus: itemsRequired ? "missing" : "complete",
+            };
             return {
-                status: "failed",
-                reason: "command_unimplemented",
-                details: "This client does not yet check assets, and instead auto-fails.",
+                status: "success",
+                result: result,
+                invalid: true,
             };
         },
     };

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { BarIpcWebContents } from "@main/typed-ipc";
+import { logger } from "@main/utils/logger";
+import { TachyonClientRequestHandlers } from "./tachyon-client";
+import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
+
+const log = logger("tachyon-handlers");
+
+export function createTachyonRequestHandlers(webContents: BarIpcWebContents): TachyonClientRequestHandlers {
+    return {
+        ...createBattleHandlers(webContents),
+        ...createMatchmakingHandlers(),
+    };
+}
+
+function createBattleHandlers(webContents: BarIpcWebContents): Pick<TachyonClientRequestHandlers, "battle/start"> {
+    return {
+        "battle/start": async (data: BattleStartRequestData) => {
+            log.info(`Received battle start request: ${JSON.stringify(data)}`);
+            const { ip, port, username, password } = data;
+            const springString = `spring://${username}:${password}@${ip}:${port}`;
+            webContents.send("tachyon:battleStart", springString);
+            return {
+                status: "success",
+            };
+        },
+    };
+}
+
+function createMatchmakingHandlers(): Pick<TachyonClientRequestHandlers, "matchmaking/checkAssets"> {
+    return {
+        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
+            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
+            return {
+                status: "failed",
+                reason: "command_unimplemented",
+                details: "This client does not yet check assets, and instead auto-fails.",
+            };
+        },
+    };
+}

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -42,12 +42,22 @@ function createBattleHandlers(webContents: BarIpcWebContents) {
             "battle/start",
             createTypedTachyonRequestHandler<"battle/start">()(async (data: BattleStartRequestData) => {
                 log.info(`Received battle start request: ${JSON.stringify(data)}`);
-                const { ip, port, username, password } = data;
-                const springString = `spring://${username}:${password}@${ip}:${port}`;
-                webContents.send("tachyon:battleStart", springString);
-                return {
-                    status: "success",
-                } satisfies ResponseBody<"battle/start">;
+                const itemsRequired =
+                    !gameContentAPI.isVersionInstalled(data.game.springName) || !mapContentAPI.isVersionInstalled(data.map.springName) || !engineContentAPI.isVersionInstalled(data.engine.version);
+                if (itemsRequired) {
+                    webContents.send("notifications:showAlert", {
+                        text: `Unable to join match, required assets are missing.`,
+                        severity: "error",
+                    });
+                    return { status: "failed", reason: "internal_error" };
+                } else {
+                    const { ip, port, username, password } = data;
+                    const springString = `spring://${username}:${password}@${ip}:${port}`;
+                    webContents.send("tachyon:battleStart", springString, data);
+                    return {
+                        status: "success",
+                    };
+                }
             })
         ),
     } satisfies Partial<TachyonClientRequestHandlers>;

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -35,7 +35,7 @@ function defineTachyonRequestHandler<C extends ServerToUserRequestId, R extends 
 export function createTachyonRequestHandlers(webContents: BarIpcWebContents): TachyonClientRequestHandlers {
     return {
         ...createBattleHandlers(webContents),
-        ...createMatchmakingHandlers(),
+        ...createMatchmakingHandlers(webContents),
     } satisfies TachyonClientRequestHandlers;
 }
 
@@ -56,7 +56,7 @@ function createBattleHandlers(webContents: BarIpcWebContents) {
     } satisfies Partial<TachyonClientRequestHandlers>;
 }
 
-function createMatchmakingHandlers() {
+function createMatchmakingHandlers(webContents: BarIpcWebContents) {
     return {
         ...defineTachyonRequestHandler(
             "matchmaking/checkAssets",
@@ -66,6 +66,13 @@ function createMatchmakingHandlers() {
                     !gameContentAPI.isVersionInstalled(data.game) ||
                     data.maps.some((map) => !mapContentAPI.isVersionInstalled(map)) ||
                     data.engines.some((engine) => !engineContentAPI.isVersionInstalled(engine));
+                if (itemsRequired) {
+                    // TODO: This should be through i18n for localization
+                    webContents.send("notifications:showAlert", {
+                        text: `Party queue rejected, missing assets required for queue ${data.queueId}.`,
+                        severity: "error",
+                    });
+                }
                 return {
                     // Reminder, "success" is returned even if some assets are missing, because it is a successful response, not an indication of asset completeness.
                     // Technically we can return "downloading" also, but for now we just return "missing" or "complete"

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -62,24 +62,13 @@ function createMatchmakingHandlers() {
             "matchmaking/checkAssets",
             createTypedTachyonRequestHandler<"matchmaking/checkAssets">()(async (data: MatchmakingCheckAssetsRequestData) => {
                 log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
-                let itemsRequired: boolean = false;
-                if (!gameContentAPI.isVersionInstalled(data.game)) {
-                    itemsRequired = true;
-                }
-                for (const map of data.maps) {
-                    if (!mapContentAPI.isVersionInstalled(map)) {
-                        itemsRequired = true;
-                        break;
-                    }
-                }
-                for (const engine of data.engines) {
-                    if (!engineContentAPI.isVersionInstalled(engine)) {
-                        itemsRequired = true;
-                        break;
-                    }
-                }
-                // Technically we can return "downloading" if any assets are missing, but for now we just return "missing" or "complete"
+                const itemsRequired =
+                    !gameContentAPI.isVersionInstalled(data.game) ||
+                    data.maps.some((map) => !mapContentAPI.isVersionInstalled(map)) ||
+                    data.engines.some((engine) => !engineContentAPI.isVersionInstalled(engine));
                 return {
+                    // Reminder, "success" is returned even if some assets are missing, because it is a successful response, not an indication of asset completeness.
+                    // Technically we can return "downloading" also, but for now we just return "missing" or "complete"
                     status: "success",
                     data: {
                         assetStatus: itemsRequired ? "missing" : "complete",

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -15,21 +15,18 @@ const log = logger("tachyon-handlers");
 
 type ServerToUserRequestId = GetCommandIds<"server", "user", "request">;
 type RequestData<C extends ServerToUserRequestId> = GetCommandData<GetCommands<"server", "user", "request", C>>;
-type ResponseBody<C extends ServerToUserRequestId> = Omit<GetCommands<"user", "server", "response", C>, "type" | "commandId" | "messageId">;
-type Exact<Expected, Actual extends Expected> = Expected & Record<Exclude<keyof Actual, keyof Expected>, never>;
+type StripEnvelope<T> = T extends object ? Omit<T, "type" | "commandId" | "messageId"> : never;
+type ResponseBody<C extends ServerToUserRequestId> = StripEnvelope<GetCommands<"user", "server", "response", C>>;
 
 const createTypedTachyonRequestHandler =
     <C extends ServerToUserRequestId>() =>
-    <R extends ResponseBody<C>>(handler: (data: RequestData<C>) => Promise<Exact<ResponseBody<C>, R>>) =>
+    (handler: (data: RequestData<C>) => Promise<ResponseBody<C>>) =>
         handler;
 
-function defineTachyonRequestHandler<C extends ServerToUserRequestId, R extends ResponseBody<C>>(
-    commandId: C,
-    handler: (data: RequestData<C>) => Promise<Exact<ResponseBody<C>, R>>
-): Pick<TachyonClientRequestHandlers, C> {
+function defineTachyonRequestHandler<C extends ServerToUserRequestId>(commandId: C, handler: (data: RequestData<C>) => Promise<ResponseBody<C>>): Pick<TachyonClientRequestHandlers, C> {
     return {
         [commandId]: handler,
-    } as unknown as Pick<TachyonClientRequestHandlers, C>;
+    } as Pick<TachyonClientRequestHandlers, C>;
 }
 
 export function createTachyonRequestHandlers(webContents: BarIpcWebContents): TachyonClientRequestHandlers {
@@ -50,7 +47,7 @@ function createBattleHandlers(webContents: BarIpcWebContents) {
                 webContents.send("tachyon:battleStart", springString);
                 return {
                     status: "success",
-                };
+                } satisfies ResponseBody<"battle/start">;
             })
         ),
     } satisfies Partial<TachyonClientRequestHandlers>;
@@ -80,7 +77,7 @@ function createMatchmakingHandlers(webContents: BarIpcWebContents) {
                     data: {
                         assetStatus: itemsRequired ? "missing" : "complete",
                     },
-                };
+                } satisfies ResponseBody<"matchmaking/checkAssets">;
             })
         ),
     } satisfies Partial<TachyonClientRequestHandlers>;

--- a/src/main/tachyon/tachyon.handlers.ts
+++ b/src/main/tachyon/tachyon.handlers.ts
@@ -4,64 +4,88 @@
 
 import { BarIpcWebContents } from "@main/typed-ipc";
 import { logger } from "@main/utils/logger";
-import { TachyonClientRequestHandlers } from "./tachyon-client";
-import { BattleStartRequestData, MatchmakingCheckAssetsOkResponseData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
+import { PartialTachyonClientRequestHandlers, TachyonClientRequestHandlers } from "./tachyon-client";
+import { GetCommandData, GetCommandIds, GetCommands } from "tachyon-protocol";
+import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { gameContentAPI } from "@main/content/game/game-content";
 import { mapContentAPI } from "@main/content/maps/map-content";
 import { engineContentAPI } from "@main/content/engine/engine-content";
 
 const log = logger("tachyon-handlers");
 
-export function createTachyonRequestHandlers(webContents: BarIpcWebContents): TachyonClientRequestHandlers {
+type ServerToUserRequestId = GetCommandIds<"server", "user", "request">;
+type RequestData<C extends ServerToUserRequestId> = GetCommandData<GetCommands<"server", "user", "request", C>>;
+type ResponseBody<C extends ServerToUserRequestId> = Omit<GetCommands<"user", "server", "response", C>, "type" | "commandId" | "messageId">;
+type Exact<Expected, Actual extends Expected> = Expected & Record<Exclude<keyof Actual, keyof Expected>, never>;
+
+const createTypedTachyonRequestHandler =
+    <C extends ServerToUserRequestId>() =>
+    <R extends ResponseBody<C>>(handler: (data: RequestData<C>) => Promise<Exact<ResponseBody<C>, R>>) =>
+        handler;
+
+function defineTachyonRequestHandler<C extends ServerToUserRequestId, R extends ResponseBody<C>>(
+    commandId: C,
+    handler: (data: RequestData<C>) => Promise<Exact<ResponseBody<C>, R>>
+): Pick<TachyonClientRequestHandlers, C> {
+    return {
+        [commandId]: handler,
+    } as unknown as Pick<TachyonClientRequestHandlers, C>;
+}
+
+export function createTachyonRequestHandlers(webContents: BarIpcWebContents): PartialTachyonClientRequestHandlers {
     return {
         ...createBattleHandlers(webContents),
         ...createMatchmakingHandlers(),
     };
 }
 
-function createBattleHandlers(webContents: BarIpcWebContents): Pick<TachyonClientRequestHandlers, "battle/start"> {
+function createBattleHandlers(webContents: BarIpcWebContents) {
     return {
-        "battle/start": async (data: BattleStartRequestData) => {
-            log.info(`Received battle start request: ${JSON.stringify(data)}`);
-            const { ip, port, username, password } = data;
-            const springString = `spring://${username}:${password}@${ip}:${port}`;
-            webContents.send("tachyon:battleStart", springString);
-            return {
-                status: "success",
-            };
-        },
-    };
+        ...defineTachyonRequestHandler(
+            "battle/start",
+            createTypedTachyonRequestHandler<"battle/start">()(async (data: BattleStartRequestData) => {
+                log.info(`Received battle start request: ${JSON.stringify(data)}`);
+                const { ip, port, username, password } = data;
+                const springString = `spring://${username}:${password}@${ip}:${port}`;
+                webContents.send("tachyon:battleStart", springString);
+                return {
+                    status: "success",
+                };
+            })
+        ),
+    } satisfies PartialTachyonClientRequestHandlers;
 }
 
-function createMatchmakingHandlers(): Pick<TachyonClientRequestHandlers, "matchmaking/checkAssets"> {
+function createMatchmakingHandlers() {
     return {
-        "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
-            log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
-            let itemsRequired: boolean = false;
-            if (!gameContentAPI.isVersionInstalled(data.game)) {
-                itemsRequired = true;
-            }
-            for (const map of data.maps) {
-                if (!mapContentAPI.isVersionInstalled(map)) {
+        ...defineTachyonRequestHandler(
+            "matchmaking/checkAssets",
+            createTypedTachyonRequestHandler<"matchmaking/checkAssets">()(async (data: MatchmakingCheckAssetsRequestData) => {
+                log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);
+                let itemsRequired: boolean = false;
+                if (!gameContentAPI.isVersionInstalled(data.game)) {
                     itemsRequired = true;
-                    break;
                 }
-            }
-            for (const engine of data.engines) {
-                if (!engineContentAPI.isVersionInstalled(engine)) {
-                    itemsRequired = true;
-                    break;
+                for (const map of data.maps) {
+                    if (!mapContentAPI.isVersionInstalled(map)) {
+                        itemsRequired = true;
+                        break;
+                    }
                 }
-            }
-            // Technically we can return "downloading" if any assets are missing, but for now we just return "missing" or "complete
-            const result: MatchmakingCheckAssetsOkResponseData = {
-                assetStatus: itemsRequired ? "missing" : "complete",
-            };
-            return {
-                status: "success",
-                result: result,
-                invalid: true,
-            };
-        },
-    };
+                for (const engine of data.engines) {
+                    if (!engineContentAPI.isVersionInstalled(engine)) {
+                        itemsRequired = true;
+                        break;
+                    }
+                }
+                // Technically we can return "downloading" if any assets are missing, but for now we just return "missing" or "complete"
+                return {
+                    status: "success",
+                    data: {
+                        assetStatus: itemsRequired ? "missing" : "complete",
+                    },
+                };
+            })
+        ),
+    } satisfies PartialTachyonClientRequestHandlers;
 }

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -197,6 +197,9 @@ async function sendQueueRequest() {
                 await sendListRequest();
             } else if (error.reason === "party_missing_asset") {
                 notificationsApi.alert({ text: "Party queue rejected, required assets are missing for the queue.", severity: "error" });
+            } else {
+                notificationsApi.alert({ text: `Queue request rejected for reason: ${error.reason}.`, severity: "error" });
+                console.error("Tachyon error: matchmaking/queue:", error);
             }
         } else {
             console.error("Tachyon error: matchmaking/queue:", error);

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -12,11 +12,11 @@ import {
     MatchmakingQueueUpdateEventData,
 } from "tachyon-protocol/types";
 import { tachyonStore } from "@renderer/store/tachyon.store";
-import { db } from "@renderer/store/db";
 import { notificationsApi } from "@renderer/api/notifications";
 import { isTachyonErrorForCommand, tachyonRequest } from "@renderer/api/tachyon";
 import { enginesStore } from "@renderer/store/engine.store";
 import { gameStore } from "@renderer/store/game.store";
+import { mapsStore } from "@renderer/store/maps.store";
 
 export enum MatchmakingStatus {
     Idle = "Idle",
@@ -135,13 +135,9 @@ async function triggerAssetsRefresh() {
 
 async function setRequiredAssetsArrays(queue: string, engines: { version: string }[], games: { springName: string }[], maps: { springName: string }[]): Promise<void> {
     matchmakingStore.downloadsRequired[queue] = { engines: [], games: [], maps: [] };
-    const queueMaps = maps.map((m) => m.springName);
-    const dbMaps = await db.maps.bulkGet(queueMaps);
-    for (const map of dbMaps) {
-        if (map != undefined && !map.isInstalled) {
-            matchmakingStore.downloadsRequired[queue].maps.push(map.springName);
-        }
-    }
+    const queueMaps = new Set(maps.map((map) => map.springName));
+    const missingMaps = queueMaps.difference(new Set(mapsStore.availableMapNames));
+    matchmakingStore.downloadsRequired[queue].maps.push(...missingMaps);
     const queueEngines = new Set(engines.map((e) => e.version));
     const installedEngines = new Set(enginesStore.availableEngineVersions.filter((e) => e.installed).map((e) => e.id));
     const diffEngines = queueEngines.difference(installedEngines);

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -191,11 +191,11 @@ async function sendQueueRequest() {
         console.log("Tachyon: matchmaking/queue:", response.status);
         matchmakingStore.status = MatchmakingStatus.Searching;
     } catch (error) {
-        if (isTachyonErrorForCommand(error, "matchmaking/queue") && error.reason === "version_mismatch") {
+        if (isTachyonErrorForCommand(error, "matchmaking/queue")) {
             if (error.reason === "version_mismatch") {
                 notificationsApi.alert({ text: "Queue version changed; refreshing list.", severity: "info" });
                 await sendListRequest();
-            } else if (error.reason === "party_assets_missing") {
+            } else if (error.reason === "party_missing_asset") {
                 notificationsApi.alert({ text: "Party queue rejected, required assets are missing for the queue.", severity: "error" });
             }
         } else {

--- a/src/renderer/store/matchmaking.store.ts
+++ b/src/renderer/store/matchmaking.store.ts
@@ -196,8 +196,12 @@ async function sendQueueRequest() {
         matchmakingStore.status = MatchmakingStatus.Searching;
     } catch (error) {
         if (isTachyonErrorForCommand(error, "matchmaking/queue") && error.reason === "version_mismatch") {
-            notificationsApi.alert({ text: "Queue version changed; refreshing list.", severity: "info" });
-            await sendListRequest();
+            if (error.reason === "version_mismatch") {
+                notificationsApi.alert({ text: "Queue version changed; refreshing list.", severity: "info" });
+                await sendListRequest();
+            } else if (error.reason === "party_assets_missing") {
+                notificationsApi.alert({ text: "Party queue rejected, required assets are missing for the queue.", severity: "error" });
+            }
         } else {
             console.error("Tachyon error: matchmaking/queue:", error);
             notificationsApi.alert({ text: "Tachyon error: matchmaking/queue", severity: "error" });

--- a/tests/unit/main/tachyon-request-handler.spec.ts
+++ b/tests/unit/main/tachyon-request-handler.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TachyonClientRequestHandlers } from "@main/tachyon/tachyon-client";
 
 const { send, gameIsInstalled, mapIsInstalled, engineIsInstalled } = vi.hoisted(() => ({
     send: vi.fn(),
@@ -35,6 +36,10 @@ function getHandlers() {
     return createTachyonRequestHandlers({ send } as never);
 }
 
+// Type coverage assertion to ensure all handlers are correctly typed
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _typeCoverageAssertion: TachyonClientRequestHandlers = getHandlers();
+
 describe("createTachyonRequestHandlers", () => {
     beforeEach(() => {
         send.mockReset();
@@ -50,7 +55,7 @@ describe("createTachyonRequestHandlers", () => {
     it("handles battle/start by sending the spring url and returning success", async () => {
         const handlers = getHandlers();
 
-        const response = await handlers["battle/start"]?.({
+        const response = await handlers["battle/start"]({
             ip: "127.0.0.1",
             port: 8452,
             username: "tester",
@@ -75,7 +80,7 @@ describe("createTachyonRequestHandlers", () => {
             engines: ["engine:105.1.1"],
         };
 
-        const response = await handlers["matchmaking/checkAssets"]?.(request);
+        const response = await handlers["matchmaking/checkAssets"](request);
 
         expect(gameIsInstalled).toHaveBeenCalledWith("byar:test-game");
         expect(mapIsInstalled).toHaveBeenCalledWith("map:comet-catcher");
@@ -93,7 +98,7 @@ describe("createTachyonRequestHandlers", () => {
         const missingMaps = new Set(["map:red-comet"]);
         mapIsInstalled.mockImplementation((map: string) => !missingMaps.has(map));
 
-        const response = await handlers["matchmaking/checkAssets"]?.({
+        const response = await handlers["matchmaking/checkAssets"]({
             queueId: "1v1",
             version: "1",
             game: "byar:test-game",

--- a/tests/unit/main/tachyon-request-handler.spec.ts
+++ b/tests/unit/main/tachyon-request-handler.spec.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { send, gameIsInstalled, mapIsInstalled, engineIsInstalled } = vi.hoisted(() => ({
+    send: vi.fn(),
+    gameIsInstalled: vi.fn(),
+    mapIsInstalled: vi.fn(),
+    engineIsInstalled: vi.fn(),
+}));
+
+vi.mock("@main/content/game/game-content", () => ({
+    gameContentAPI: {
+        isVersionInstalled: gameIsInstalled,
+    },
+}));
+
+vi.mock("@main/content/maps/map-content", () => ({
+    mapContentAPI: {
+        isVersionInstalled: mapIsInstalled,
+    },
+}));
+
+vi.mock("@main/content/engine/engine-content", () => ({
+    engineContentAPI: {
+        isVersionInstalled: engineIsInstalled,
+    },
+}));
+
+const { createTachyonRequestHandlers } = await import("@main/tachyon/tachyon.handlers");
+
+function getHandlers() {
+    return createTachyonRequestHandlers({ send } as never);
+}
+
+describe("createTachyonRequestHandlers", () => {
+    beforeEach(() => {
+        send.mockReset();
+        gameIsInstalled.mockReset();
+        mapIsInstalled.mockReset();
+        engineIsInstalled.mockReset();
+
+        gameIsInstalled.mockReturnValue(true);
+        mapIsInstalled.mockReturnValue(true);
+        engineIsInstalled.mockReturnValue(true);
+    });
+
+    it("handles battle/start by sending the spring url and returning success", async () => {
+        const handlers = getHandlers();
+
+        const response = await handlers["battle/start"]?.({
+            ip: "127.0.0.1",
+            port: 8452,
+            username: "tester",
+            password: "secret",
+            engine: { version: "105.1.1" },
+            game: { springName: "byar:test-game" },
+            map: { springName: "map:comet-catcher" },
+        });
+
+        expect(send).toHaveBeenCalledWith("tachyon:battleStart", "spring://tester:secret@127.0.0.1:8452");
+        expect(response).toEqual({ status: "success" });
+    });
+
+    it("returns complete when game, maps, and engines are all installed", async () => {
+        const handlers = getHandlers();
+
+        const request = {
+            queueId: "1v1",
+            version: "1",
+            game: "byar:test-game",
+            maps: ["map:comet-catcher", "map:red-comet"],
+            engines: ["engine:105.1.1"],
+        };
+
+        const response = await handlers["matchmaking/checkAssets"]?.(request);
+
+        expect(gameIsInstalled).toHaveBeenCalledWith("byar:test-game");
+        expect(mapIsInstalled).toHaveBeenCalledWith("map:comet-catcher");
+        expect(mapIsInstalled).toHaveBeenCalledWith("map:red-comet");
+        expect(engineIsInstalled).toHaveBeenCalledWith("engine:105.1.1");
+        expect(response).toEqual({
+            status: "success",
+            data: { assetStatus: "complete" },
+        });
+    });
+
+    it("returns missing when any required item is not installed", async () => {
+        const handlers = getHandlers();
+
+        const missingMaps = new Set(["map:red-comet"]);
+        mapIsInstalled.mockImplementation((map: string) => !missingMaps.has(map));
+
+        const response = await handlers["matchmaking/checkAssets"]?.({
+            queueId: "1v1",
+            version: "1",
+            game: "byar:test-game",
+            maps: ["map:comet-catcher", "map:red-comet"],
+            engines: ["engine:105.1.1"],
+        });
+
+        expect(gameIsInstalled).toHaveBeenCalledWith("byar:test-game");
+        expect(mapIsInstalled).toHaveBeenCalledWith("map:comet-catcher");
+        expect(mapIsInstalled).toHaveBeenCalledWith("map:red-comet");
+        expect(response).toEqual({
+            status: "success",
+            data: { assetStatus: "missing" },
+        });
+    });
+});

--- a/tests/unit/main/tachyon-request-handler.spec.ts
+++ b/tests/unit/main/tachyon-request-handler.spec.ts
@@ -4,6 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TachyonClientRequestHandlers } from "@main/tachyon/tachyon-client";
+import { BattleStartRequestData } from "tachyon-protocol/types";
 
 const { send, gameIsInstalled, mapIsInstalled, engineIsInstalled } = vi.hoisted(() => ({
     send: vi.fn(),
@@ -52,10 +53,9 @@ describe("createTachyonRequestHandlers", () => {
         engineIsInstalled.mockReturnValue(true);
     });
 
-    it("handles battle/start by sending the spring url and returning success", async () => {
+    it("handles battle/start by sending the spring url, data, and returning success", async () => {
         const handlers = getHandlers();
-
-        const response = await handlers["battle/start"]({
+        const data: BattleStartRequestData = {
             ip: "127.0.0.1",
             port: 8452,
             username: "tester",
@@ -63,9 +63,10 @@ describe("createTachyonRequestHandlers", () => {
             engine: { version: "105.1.1" },
             game: { springName: "byar:test-game" },
             map: { springName: "map:comet-catcher" },
-        });
+        };
+        const response = await handlers["battle/start"](data);
 
-        expect(send).toHaveBeenCalledWith("tachyon:battleStart", "spring://tester:secret@127.0.0.1:8452");
+        expect(send).toHaveBeenCalledWith("tachyon:battleStart", "spring://tester:secret@127.0.0.1:8452", data);
         expect(response).toEqual({ status: "success" });
     });
 


### PR DESCRIPTION
Refactors Tachyon request handlers (server-to-client) for cleaner, type-safe code.
* Structured in a separate file where new requests should be added in the future
* Unhandled requests will log the problem and respond with failure using `command_unimplemented` or `internal_error`
* `matchmaking/checkAssets` is newly implemented for the client

### AI / LLM usage statement:
GitHub Copilot was used to generate the code and tests for this PR. This was done in small, directed batches to ensure minimal LLM bloat and close adherence to desired implementation.