### PR TITLE
Fix missing preset startboxes in the battle preview

### DIFF
--- a/src/renderer/store/battle.store.ts
+++ b/src/renderer/store/battle.store.ts
@@ -217,7 +217,7 @@ function getNumberOfTeams(): number {
     if (battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes) {
         const startBoxIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
 
-        if (startBoxIndex != undefined && map.startboxesSet[startBoxIndex] != undefined) {
+        if (startBoxIndex != undefined && map.startboxesSet?.[startBoxIndex] != undefined) {
             const startBoxes = map.startboxesSet[startBoxIndex];
             numberOfTeams = startBoxes.startboxes.length;
         } else if (battleStore.battleOptions.mapOptions.customStartBoxes) {
@@ -245,7 +245,7 @@ function getMaxPlayersPerTeam() {
     if (battleStore.battleOptions.mapOptions.startPosType === StartPosType.Boxes) {
         const startBoxIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
 
-        if (startBoxIndex != undefined && map.startboxesSet[startBoxIndex] != undefined) {
+        if (startBoxIndex != undefined && map.startboxesSet?.[startBoxIndex] != undefined) {
             const startBoxes = map.startboxesSet[startBoxIndex];
             maxPlayersPerTeam = startBoxes.maxPlayersPerStartbox;
         } else if (battleStore.battleOptions.mapOptions.customStartBoxes) {
@@ -290,35 +290,40 @@ function updateTeams() {
     }
 }
 
+function eastVsWestStartBoxes(): Array<StartBox> {
+    return [
+        {
+            top: 0,
+            bottom: 1,
+            left: 0,
+            right: 0.25,
+        },
+        {
+            top: 0,
+            bottom: 1,
+            left: 0.75,
+            right: 1,
+        },
+    ];
+}
+
+// Read-only: this runs inside render-time computeds, so it must never write back
+// to mapOptions. Latching the battle into custom boxes for a map with no presets
+// is the map watcher's job.
 function getCurrentStartBoxes(): Array<StartBox> {
-    const startBoxesIndex = battleStore.battleOptions.mapOptions.startBoxesIndex;
-    if (startBoxesIndex != undefined) {
-        if (battleStore.battleOptions.map?.startboxesSet[startBoxesIndex] != undefined) {
-            return battleStore.battleOptions.map?.startboxesSet.at(startBoxesIndex)?.startboxes.map((box) => spadsBoxToStartBox(box.poly)) || [];
-        } else {
-            // In this case the map has no startboxes at all, which will crash the client unless we set some.
-            const defaultBoxes = [
-                {
-                    top: 0,
-                    bottom: 1,
-                    left: 0,
-                    right: 0.25,
-                },
-                {
-                    top: 0,
-                    bottom: 1,
-                    left: 0.75,
-                    right: 1,
-                },
-            ];
-            // Clearing the index means we set to custom boxes, which is best since we have zero presets anyway.
-            battleStore.battleOptions.mapOptions.customStartBoxes = defaultBoxes;
-            battleStore.battleOptions.mapOptions.startBoxesIndex = undefined;
-            return defaultBoxes;
-        }
-    } else {
-        return battleStore.battleOptions.mapOptions.customStartBoxes as Array<StartBox>;
+    const mapOptions = battleStore.battleOptions.mapOptions;
+    const startBoxesIndex = mapOptions.startBoxesIndex;
+
+    if (startBoxesIndex == undefined) {
+        return mapOptions.customStartBoxes ?? [];
     }
+
+    const preset = battleStore.battleOptions.map?.startboxesSet?.at(startBoxesIndex);
+    if (preset) {
+        return preset.startboxes.map((box) => spadsBoxToStartBox(box.poly));
+    }
+
+    return mapOptions.customStartBoxes ?? eastVsWestStartBoxes();
 }
 
 function addCustomStartBox() {
@@ -445,9 +450,19 @@ watch(
 watch(
     () => battleStore.battleOptions.map,
     () => {
-        battleStore.battleOptions.mapOptions.startPosType = StartPosType.Boxes;
-        battleStore.battleOptions.mapOptions.startBoxesIndex = 0;
-        if (battleStore.me) battleStore.me.contentSyncState.map = battleStore.battleOptions.map?.isInstalled ? 1 : 0;
+        const map = battleStore.battleOptions.map;
+        const mapOptions = battleStore.battleOptions.mapOptions;
+
+        mapOptions.startPosType = StartPosType.Boxes;
+
+        if (map && !map.startboxesSet?.length) {
+            mapOptions.customStartBoxes = eastVsWestStartBoxes();
+            mapOptions.startBoxesIndex = undefined;
+        } else {
+            mapOptions.startBoxesIndex = 0;
+        }
+
+        if (battleStore.me) battleStore.me.contentSyncState.map = map?.isInstalled ? 1 : 0;
         updateTeams();
     },
     { deep: true }

--- a/tests/unit/renderer/battle-start-boxes.spec.ts
+++ b/tests/unit/renderer/battle-start-boxes.spec.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { MapData } from "@main/content/maps/map-data";
+import { StartPosType } from "@main/game/battle/battle-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+vi.mock("@renderer/store/db", () => ({
+    db: { maps: {}, nonLiveMaps: {}, replays: {}, users: {} },
+}));
+
+vi.mock("@renderer/store/game.store", () => ({
+    gameStore: { selectedGameVersion: undefined },
+    startBattle: vi.fn(),
+}));
+
+vi.mock("@renderer/store/engine.store", () => ({
+    enginesStore: { selectedEngineVersion: undefined },
+}));
+
+vi.mock("@renderer/store/maps.store", () => ({
+    getRandomMap: vi.fn(),
+}));
+
+vi.mock("@renderer/store/me.store", () => ({
+    me: { userId: "1", username: "me", status: "menu", battleRoomState: {} },
+}));
+
+vi.mock("@renderer/api/notifications", () => ({
+    notificationsApi: { alert: vi.fn() },
+}));
+
+const { battleStore, battleActions } = await import("@renderer/store/battle.store");
+
+function mapWith(startboxesSet: MapData["startboxesSet"]) {
+    return { springName: "Test Map", playerCountMax: 8, startboxesSet } as MapData;
+}
+
+const twoBoxPreset = [
+    {
+        maxPlayersPerStartbox: 4,
+        startboxes: [
+            {
+                poly: [
+                    { x: 0, y: 0 },
+                    { x: 40, y: 200 },
+                ],
+            },
+            {
+                poly: [
+                    { x: 160, y: 0 },
+                    { x: 200, y: 200 },
+                ],
+            },
+        ],
+    },
+];
+
+describe("getCurrentStartBoxes", () => {
+    beforeEach(async () => {
+        battleActions.resetToDefaultBattle();
+        await nextTick();
+        battleStore.battleOptions.mapOptions = { startPosType: StartPosType.Boxes, startBoxesIndex: 0 };
+    });
+
+    it("leaves a chosen preset alone while no map is selected yet", () => {
+        battleActions.getCurrentStartBoxes();
+
+        expect(battleStore.battleOptions.mapOptions.startBoxesIndex).toBe(0);
+        expect(battleStore.battleOptions.mapOptions.customStartBoxes).toBeUndefined();
+    });
+
+    it("returns the preset boxes for the selected index", () => {
+        battleStore.battleOptions.map = mapWith(twoBoxPreset);
+        battleStore.battleOptions.mapOptions.startBoxesIndex = 0;
+
+        expect(battleActions.getCurrentStartBoxes()).toEqual([
+            { left: 0, top: 0, right: 0.2, bottom: 1 },
+            { left: 0.8, top: 0, right: 1, bottom: 1 },
+        ]);
+    });
+
+    it("falls back to east vs west for a map that ships no presets", async () => {
+        battleStore.battleOptions.map = mapWith([]);
+        await nextTick();
+
+        expect(battleStore.battleOptions.mapOptions.startBoxesIndex).toBeUndefined();
+        expect(battleActions.getCurrentStartBoxes()).toHaveLength(2);
+    });
+
+    it("selects preset 0 when a map with presets is chosen", async () => {
+        battleStore.battleOptions.map = mapWith(twoBoxPreset);
+        await nextTick();
+
+        expect(battleStore.battleOptions.mapOptions.startBoxesIndex).toBe(0);
+    });
+});


### PR DESCRIPTION
The battle preview only ever showed startboxes you had drawn yourself. The map's own presets never appeared, and clicking a preset button did nothing.

`getCurrentStartBoxes` was writing back to the store while the preview rendered, and its "this map has no startboxes" check couldn't tell that case apart from "no map is selected yet". The preview is mounted from app start, before any map exists, so it ran early, decided the map had no presets, and flipped the battle over to custom boxes. From then on any preset you picked got wiped again on the next read. It looked like changing maps fixed it, but that only worked because the map watcher resets the index.

The fix is to make that function read-only and move the no-presets handling into the map watcher, where we actually know what the map is. The crash guard from #557 that the branch originally came from still holds, so a map with an empty set still gets fallback boxes.

Verified by driving the running client through all 225 maps and their 291 presets and comparing the rendered boxes against the metadata. One map is left over and it isn't a client problem: The Desert Triad Remake v1.0 ships an empty `startboxesSet` upstream, so it has nothing to show and lands on the fallback.

AI disclosure: written with assistance from Claude Code.
