### PR TITLE
Make switching the active server take effect

### DIFF
--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -4,9 +4,10 @@
 
 import { Me } from "@main/model/user";
 import { db } from "@renderer/store/db";
-import { reactive, toRaw } from "vue";
+import { reactive, toRaw, watch } from "vue";
 import { tachyonStore } from "@renderer/store/tachyon.store";
 import { PrivateUser } from "tachyon-protocol/types";
+import { settingsStore } from "@renderer/store/settings.store";
 import { subsManager } from "@renderer/store/users.store";
 
 export const me = reactive<
@@ -67,6 +68,16 @@ async function logout() {
 }
 
 async function changeAccount() {
+    await window.auth.wipe();
+    me.isAuthenticated = false;
+}
+
+// The same setting picks the websocket and the authorization server, so the
+// credentials we are holding were issued by the server being left and are worth
+// nothing to the one being joined. Switching ends the session rather than moving
+// the socket over.
+async function serverChanged() {
+    await window.tachyon.disconnect();
     await window.auth.wipe();
     me.isAuthenticated = false;
 }
@@ -210,6 +221,18 @@ export const friends = {
 };
 
 export async function initMeStore() {
+    // Settings load in parallel with this, and the stored server arriving over
+    // the default counts as a change. Reacting to that would sign out everyone
+    // who does not use the default server, every launch.
+    watch(
+        () => settingsStore.lobbyServer,
+        () => {
+            if (!settingsStore.isInitialized) return;
+
+            void serverChanged();
+        }
+    );
+
     await db.users
         .where({ isMe: 1 })
         .first()

--- a/src/renderer/store/me.store.ts
+++ b/src/renderer/store/me.store.ts
@@ -77,9 +77,12 @@ async function changeAccount() {
 // nothing to the one being joined. Switching ends the session rather than moving
 // the socket over.
 async function serverChanged() {
+    // A socket that drops while we still look authenticated is treated as a
+    // connection worth retrying, so give up the session before closing it.
+    me.isAuthenticated = false;
+    subsManager.clearAllFromList(friendsSymbol);
     await window.tachyon.disconnect();
     await window.auth.wipe();
-    me.isAuthenticated = false;
 }
 
 window.tachyon.onEvent("user/self", async (event) => {

--- a/tests/unit/renderer/server-switch.spec.ts
+++ b/tests/unit/renderer/server-switch.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+vi.mock("@renderer/store/db", () => ({
+    db: { users: { where: () => ({ first: async () => undefined, modify: async () => undefined }), put: vi.fn() } },
+}));
+
+const disconnect = vi.fn(async () => {});
+const wipe = vi.fn(async () => {});
+
+Object.assign(window.tachyon, { disconnect });
+Object.defineProperty(window, "auth", {
+    value: { wipe, hasCredentials: vi.fn(async () => false), login: vi.fn(async () => {}), logout: vi.fn(async () => {}) },
+    writable: true,
+});
+
+const { me, initMeStore } = await import("@renderer/store/me.store");
+const { settingsStore } = await import("@renderer/store/settings.store");
+
+async function changeServerTo(server: string) {
+    settingsStore.lobbyServer = server;
+    await nextTick();
+}
+
+describe("switching the active server", () => {
+    // Registers the watcher, and there is no guard against doing it twice, so
+    // calling it per test would stack one watcher per case.
+    beforeAll(async () => {
+        await initMeStore();
+    });
+
+    beforeEach(async () => {
+        disconnect.mockClear();
+        wipe.mockClear();
+        settingsStore.isInitialized = false;
+        settingsStore.lobbyServer = "wss://server4.beyondallreason.info";
+        await nextTick();
+    });
+
+    // Settings load in parallel with the store that watches them, so the stored
+    // server arriving over the default is a change as far as the watcher is
+    // concerned. Acting on it would sign out everyone not on the default server,
+    // every launch.
+    it("ignores the stored server arriving while settings are still loading", async () => {
+        me.isAuthenticated = true;
+
+        await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
+
+        expect(wipe).not.toHaveBeenCalled();
+        expect(disconnect).not.toHaveBeenCalled();
+        expect(me.isAuthenticated).toBe(true);
+    });
+
+    describe("once settings are loaded", () => {
+        beforeEach(() => {
+            settingsStore.isInitialized = true;
+            me.isAuthenticated = true;
+        });
+
+        // The same setting picks the authorization server, so the tokens we hold
+        // were issued somewhere that has no say over the server being joined.
+        it("throws the credentials away rather than carrying them over", async () => {
+            await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
+
+            expect(wipe).toHaveBeenCalledOnce();
+            expect(me.isAuthenticated).toBe(false);
+        });
+
+        it("closes the connection to the server being left", async () => {
+            await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
+
+            expect(disconnect).toHaveBeenCalledOnce();
+        });
+
+        it("does nothing when the same server is picked again", async () => {
+            await changeServerTo("wss://server4.beyondallreason.info");
+
+            expect(wipe).not.toHaveBeenCalled();
+            expect(disconnect).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/unit/renderer/server-switch.spec.ts
+++ b/tests/unit/renderer/server-switch.spec.ts
@@ -76,6 +76,19 @@ describe("switching the active server", () => {
             expect(disconnect).toHaveBeenCalledOnce();
         });
 
+        // A drop while we still look authenticated gets a reconnect timer, which
+        // then keeps firing against credentials that are already gone.
+        it("has given up the session before the connection closes", async () => {
+            let authenticatedWhenClosing: boolean | undefined;
+            disconnect.mockImplementationOnce(async () => {
+                authenticatedWhenClosing = me.isAuthenticated;
+            });
+
+            await changeServerTo("wss://lobby-server-dev.beyondallreason.dev");
+
+            expect(authenticatedWhenClosing).toBe(false);
+        });
+
         it("does nothing when the same server is picked again", async () => {
             await changeServerTo("wss://server4.beyondallreason.info");
 

--- a/tests/unit/renderer/server-switch.spec.ts
+++ b/tests/unit/renderer/server-switch.spec.ts
@@ -11,8 +11,9 @@ vi.mock("@renderer/store/db", () => ({
 
 const disconnect = vi.fn(async () => {});
 const wipe = vi.fn(async () => {});
+const onConnected = vi.fn(async () => {});
 
-Object.assign(window.tachyon, { disconnect });
+Object.assign(window.tachyon, { disconnect, onConnected });
 Object.defineProperty(window, "auth", {
     value: { wipe, hasCredentials: vi.fn(async () => false), login: vi.fn(async () => {}), logout: vi.fn(async () => {}) },
     writable: true,


### PR DESCRIPTION
Picking a different active server only wrote the setting - nothing watched it, so the connection stayed on the old one while the modal claimed the change had immediate effect.

Switching ends the session rather than moving the socket over, since that setting picks the authorization server too and the stored tokens came from the server being left.

Turned up while testing #657, there's no issue for it.

AI disclosure: written with assistance from Claude Code.
