### PR TITLE
battle/start fixes, more Custom Lobby buttons

### DIFF
--- a/src/main/services/tachyon.service.ts
+++ b/src/main/services/tachyon.service.ts
@@ -8,6 +8,9 @@ import { logger } from "@main/utils/logger";
 import { ipcMain } from "electron";
 import { BattleStartRequestData, MatchmakingCheckAssetsRequestData } from "tachyon-protocol/types";
 import { BarIpcWebContents } from "@main/typed-ipc";
+import { gameContentAPI } from "@main/content/game/game-content";
+import { mapContentAPI } from "@main/content/maps/map-content";
+import { engineContentAPI } from "@main/content/engine/engine-content";
 
 const log = logger("tachyon-service");
 
@@ -15,12 +18,22 @@ function registerIpcHandlers(webContents: BarIpcWebContents) {
     const requestHandlers: TachyonClientRequestHandlers = {
         "battle/start": async (data: BattleStartRequestData) => {
             log.info(`Received battle start request: ${JSON.stringify(data)}`);
-            const { ip, port, username, password } = data;
-            const springString = `spring://${username}:${password}@${ip}:${port}`;
-            webContents.send("tachyon:battleStart", springString);
-            return {
-                status: "success",
-            };
+            const itemsRequired =
+                !gameContentAPI.isVersionInstalled(data.game.springName) || !mapContentAPI.isVersionInstalled(data.map.springName) || !engineContentAPI.isVersionInstalled(data.engine.version);
+            if (itemsRequired) {
+                webContents.send("notifications:showAlert", {
+                    text: `Unable to join match, required assets are missing.`,
+                    severity: "error",
+                });
+                return { status: "failed", reason: "internal_error" };
+            } else {
+                const { ip, port, username, password } = data;
+                const springString = `spring://${username}:${password}@${ip}:${port}`;
+                webContents.send("tachyon:battleStart", springString, data);
+                return {
+                    status: "success",
+                };
+            }
         },
         "matchmaking/checkAssets": async (data: MatchmakingCheckAssetsRequestData) => {
             log.info(`Received matchmaking check assets request: ${JSON.stringify(data)}`);

--- a/src/main/typed-ipc.ts
+++ b/src/main/typed-ipc.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { BattleWithMetadata } from "@main/game/battle/battle-types";
+import type { BattleStartRequestData } from "tachyon-protocol/types";
 import type { DownloadInfo } from "@main/content/downloads";
 import type { EngineVersion } from "@main/content/engine/engine-version";
 import type { GameVersion } from "@main/content/game/game-version";
@@ -51,7 +52,7 @@ export type IPCEvents = {
     "replays:replayCachingStarted": (filename: string) => void;
     "replays:replayDeleted": (filename: string) => void;
     "replays:highlightOpened": (fileNames: string[]) => void;
-    "tachyon:battleStart": (springString: string) => void;
+    "tachyon:battleStart": (springString: string, data: BattleStartRequestData) => void;
     "tachyon:connected": () => void;
     "tachyon:disconnected": () => void;
     "tachyon:event": (event: TachyonEvent) => void;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -13,6 +13,7 @@ import { DownloadInfo } from "@main/content/downloads";
 import { Info } from "@main/services/info.service";
 import { BattleWithMetadata } from "@main/game/battle/battle-types";
 import { GetCommandData, GetCommandIds, GetCommands } from "tachyon-protocol";
+import type { BattleStartRequestData } from "tachyon-protocol/types";
 import { MultiplayerLaunchSettings } from "@main/game/game";
 import { logLevels } from "@main/services/log.service";
 
@@ -238,7 +239,7 @@ const tachyonApi = {
     onConnected: (callback: () => void) => ipcRenderer.on("tachyon:connected", callback),
     onDisconnected: (callback: () => void) => ipcRenderer.on("tachyon:disconnected", callback),
     onEvent,
-    onBattleStart: (callback: (springString: string) => void) => ipcRenderer.on("tachyon:battleStart", (_event, springString) => callback(springString)),
+    onBattleStart: (callback: (springString: string, data: BattleStartRequestData) => void) => ipcRenderer.on("tachyon:battleStart", (_event, springString, data) => callback(springString, data)),
 };
 export type TachyonApi = typeof tachyonApi;
 contextBridge.exposeInMainWorld("tachyon", tachyonApi);

--- a/src/renderer/store/tachyon.store.ts
+++ b/src/renderer/store/tachyon.store.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { enginesStore } from "@renderer/store/engine.store";
-import { gameStore } from "@renderer/store/game.store";
 import { auth, me } from "@renderer/store/me.store";
 import { SystemServerStatsOkResponseData } from "tachyon-protocol/types";
 import { reactive } from "vue";
@@ -108,20 +106,12 @@ export async function initTachyonStore() {
         }
     });
 
-    window.tachyon.onBattleStart((springString) => {
+    window.tachyon.onBattleStart((springString, data) => {
         console.debug("Received battle start event", springString);
-        const engineVersion = enginesStore.selectedEngineVersion;
-        if (engineVersion === undefined) {
-            console.error("No engine version selected");
-            return;
-        }
-        if (!gameStore.selectedGameVersion) {
-            console.error("No game version selected");
-            return;
-        }
+        // tachyon.service.ts checks assets before sending this request here.
         window.game.launchMultiplayer({
-            engineVersion: engineVersion.id,
-            gameVersion: gameStore.selectedGameVersion.gameVersion,
+            engineVersion: data.engine.version,
+            gameVersion: data.game.springName,
             springString,
         });
     });

--- a/src/renderer/views/play/lobby.vue
+++ b/src/renderer/views/play/lobby.vue
@@ -12,6 +12,10 @@ SPDX-License-Identifier: MIT
     <Panel>
         <div class="flex flex-row">
             <Button @click="startGame()" class="green" :disabled="isMapNeeded">Start Game</Button>
+            <Button @click="joinQueue()" class="green">Join Queue</Button>
+            <Button @click="joinSpectate()" class="green">Join Spectate</Button>
+            <Button @click="updateReadiness(true)" class="green">Ready</Button>
+            <Button @click="updateReadiness(false)" class="red">Not Ready</Button>
             <Button @click="fetchMap()" class="red flex-right" :disabled="!isMapNeeded || downloadsStore.isPathChanging"
                 >Download Map</Button
             >
@@ -67,6 +71,16 @@ function leaveLobby() {
 
 function startGame() {
     lobby.requestStartBattle();
+}
+function joinQueue() {
+    lobby.requestJoinQueue();
+}
+function joinSpectate() {
+    lobby.requestSpectate();
+}
+// TODO: Ready status should be automatically watched. This is temp for manually claiming readiness.
+function updateReadiness(isReady: boolean) {
+    lobby.requestUpdateClientStatus({ isReady: isReady });
 }
 const isMapNeeded = computed(() => {
     return lobbyStore.activeLobby ? !mapsStore.availableMapNames.has(lobbyStore.activeLobby.mapName) : false;


### PR DESCRIPTION
Fix: Request handler for `battle/start` did not honor the appropriate engine/game version, instead preferring a locally selected option which may or may not have been correct for the autohost.
Fix: Request handler for `battle/start` did not attempt to check for assets before trying to launch.
Feat: Added controls to `lobby.vue` to enable more basic lobby functions.