### PR TITLE
Check generated language files against their source in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,12 @@ jobs:
             - name: Lint check
               run: npm run lint
 
+            # The language files under src/renderer/assets are generated from lang/, and nothing else
+            # checks the two agree: a key added straight to the generated side passes types, lint and
+            # tests, then disappears the next time anyone regenerates.
+            - name: Translation assets are up to date
+              run: npm run generate-i18n-assets:check
+
             - name: Test Vite Build
               run: npm run package
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "typecheck": "concurrently \"npm run typecheck:node\" \"npm run typecheck:web\"",
         "checks": "concurrently \"npm run typecheck:web\" \"npm run typecheck:node\" \"npm run lint\" \"npm run format:check\"",
         "generate-i18n-assets": "node --import=tsx tools/generate-i18n-asset-files.ts",
+        "generate-i18n-assets:check": "npm run generate-i18n-assets && git diff --exit-code -- src/renderer/assets/languages",
         "start:multi": "node --import=tsx tools/launch-clients.ts"
     },
     "engines": {


### PR DESCRIPTION
The files under `src/renderer/assets/languages` are generated from `lang/`, and nothing checked that the two still agreed. Adding a key straight to the generated side passes types, lint and tests and works in the running client, right up until the next `generate-i18n-assets` run quietly deletes it. That is how #675 lost a string, spotted by eye in review rather than by anything automated.

Types do not help here even though it looks like they should: the schema is `typeof enTranslation` off the generated file, so `t("some.key.that.does.not.exist")` compiles clean. I checked before assuming otherwise.

The step regenerates and fails on a dirty tree, so it catches drift either way round - a key added to the generated output, or one added to `lang/` without regenerating. Verified both, and master regenerates with no diff today so this goes green as-is.

Kept out of `npm run checks` deliberately: that runs its parts concurrently and this one writes the files the others are reading.

AI disclosure: written with assistance from Claude Code.
