### PR TITLE
Use "barreplay" extension locally

### DIFF
--- a/src/main/game/springsettings.ts
+++ b/src/main/game/springsettings.ts
@@ -101,6 +101,7 @@ const BAR_SPRINGSETTINGS_DEFAULTS: Record<string, string | number> = {
     LinkIncomingSustainedBandwidth: 1048576,
     LinkIncomingPeakBandwidth: 1048576,
     LinkIncomingMaxPacketRate: 2048,
+    DemoFileExtension: "barreplay",
 };
 
 function readSettings(filePath: string): Map<string, string> {


### PR DESCRIPTION
This will result in local replays being generated with the `barreplay` extension.