### PR TITLE
Added SDFZ to valid replays

### DIFF
--- a/src/main/game/springsettings.ts
+++ b/src/main/game/springsettings.ts
@@ -101,7 +101,7 @@ const BAR_SPRINGSETTINGS_DEFAULTS: Record<string, string | number> = {
     LinkIncomingSustainedBandwidth: 1048576,
     LinkIncomingPeakBandwidth: 1048576,
     LinkIncomingMaxPacketRate: 2048,
-    DemoFileExtension: "barreplay",
+    DemoFileExtension: "barreplay,sdfz",
 };
 
 function readSettings(filePath: string): Map<string, string> {


### PR DESCRIPTION
Spring Setting `DemoFileExtension` needed to have comma separated value for both the new `barreplay` as well as the original `sdfz` for both to be recognized simultaneously.