### PR TITLE
feat(devlog): link dev blog entries to their source

### DIFF
--- a/lang/dev/lobby.json
+++ b/lang/dev/lobby.json
@@ -393,6 +393,10 @@
                 "devlogFeed": {
                     "latestChanges": "Lasett cngaehs"
                 },
+                "devlogEntry": {
+                    "title": "Deolvg Title",
+                    "description": "Deolvg Deitipocrsn"
+                },
                 "preloader": {
                     "loading": "Lndiaog",
                     "loadingFonts": "Lndiaog ftnos",
@@ -425,10 +429,6 @@
                     "couldNotUploadLog": "Culod not upolad log.",
                     "reload": "Rolead",
                     "quitToDesktop": "Quit to Dektosp"
-                },
-                "devlogEntry": {
-                    "title": "Deolvg Title",
-                    "description": "Deolvg Deitipocrsn"
                 },
                 "initialSetup": {
                     "title": "Iniaitl Stuep",

--- a/lang/dev/lobby.json
+++ b/lang/dev/lobby.json
@@ -32,7 +32,8 @@
             }
         },
         "buttons": {
-            "quickPlay": "Qiuck paly"
+            "quickPlay": "Qiuck paly",
+            "readMore": "Raed more..."
         },
         "composables": {
             "useTerrainIcon": {
@@ -393,10 +394,6 @@
                 "devlogFeed": {
                     "latestChanges": "Lasett cngaehs"
                 },
-                "devlogEntry": {
-                    "title": "Deolvg Title",
-                    "description": "Deolvg Deitipocrsn"
-                },
                 "preloader": {
                     "loading": "Lndiaog",
                     "loadingFonts": "Lndiaog ftnos",
@@ -429,6 +426,10 @@
                     "couldNotUploadLog": "Culod not upolad log.",
                     "reload": "Rolead",
                     "quitToDesktop": "Quit to Dektosp"
+                },
+                "devlogEntry": {
+                    "title": "Deolvg Title",
+                    "description": "Deolvg Deitipocrsn"
                 },
                 "initialSetup": {
                     "title": "Iniaitl Stuep",

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -32,7 +32,8 @@
             }
         },
         "buttons": {
-            "quickPlay": "Quick play"
+            "quickPlay": "Quick play",
+            "readMore": "Read more..."
         },
         "composables": {
             "useTerrainIcon": {
@@ -392,9 +393,6 @@
                 },
                 "devlogFeed": {
                     "latestChanges": "Latest changes"
-                },
-                "devlogEntry": {
-                    "readMore": "Read more..."
                 },
                 "preloader": {
                     "loading": "Loading",

--- a/lang/en/lobby.json
+++ b/lang/en/lobby.json
@@ -393,6 +393,9 @@
                 "devlogFeed": {
                     "latestChanges": "Latest changes"
                 },
+                "devlogEntry": {
+                    "readMore": "Read more..."
+                },
                 "preloader": {
                     "loading": "Loading",
                     "loadingFonts": "Loading fonts",

--- a/src/main/json/model/config.ts
+++ b/src/main/json/model/config.ts
@@ -24,7 +24,9 @@ export const configSchema = Type.Object({
     mapsMetadataUrl: Type.String({ default: "https://maps-metadata.beyondallreason.dev/latest/lobby_maps.validated.json" }),
     newsRssUrl: Type.String({ default: "https://www.beyondallreason.info/news/rss.xml" }),
     devlogRssUrl: Type.String({ default: "https://www.beyondallreason.info/microblogs/rss.xml" }),
-    allowedUrlLinks: Type.Array(Type.String(), { default: ["https://bar-rts.com/replays", "https://www.beyondallreason.info/news"] }),
+    allowedUrlLinks: Type.Array(Type.String(), {
+        default: ["https://bar-rts.com/replays", "https://www.beyondallreason.info/news", "https://www.beyondallreason.info/microblogs"],
+    }),
     replayServiceUrl: Type.String({ default: "https://bar-rts.com/replays" }),
     onlineReplaysApiUrl: Type.String({ default: "https://api.bar-rts.com/replays" }),
     defaultServers: Type.Array(Type.String(), {

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2015,7 +2015,8 @@
             }
         },
         "buttons": {
-            "quickPlay": null
+            "quickPlay": null,
+            "readMore": null
         },
         "composables": {
             "useTerrainIcon": {
@@ -2376,10 +2377,6 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
-                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -2412,6 +2409,10 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
+                },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/cs.json
+++ b/src/renderer/assets/languages/cs.json
@@ -2376,6 +2376,10 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
+                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -2408,10 +2412,6 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
-                },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -1855,7 +1855,8 @@
     },
     "lobby": {
         "buttons": {
-            "quickPlay": "Quick play in german"
+            "quickPlay": "Quick play in german",
+            "readMore": null
         },
         "api": {
             "shell": {
@@ -2247,10 +2248,6 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
-                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -2283,6 +2280,10 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
+                },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/de.json
+++ b/src/renderer/assets/languages/de.json
@@ -2247,6 +2247,10 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
+                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -2279,10 +2283,6 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
-                },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/dev.json
+++ b/src/renderer/assets/languages/dev.json
@@ -393,6 +393,10 @@
                 "devlogFeed": {
                     "latestChanges": "Lasett cngaehs"
                 },
+                "devlogEntry": {
+                    "title": "Deolvg Title",
+                    "description": "Deolvg Deitipocrsn"
+                },
                 "preloader": {
                     "loading": "Lndiaog",
                     "loadingFonts": "Lndiaog ftnos",
@@ -425,10 +429,6 @@
                     "couldNotUploadLog": "Culod not upolad log.",
                     "reload": "Rolead",
                     "quitToDesktop": "Quit to Dektosp"
-                },
-                "devlogEntry": {
-                    "title": "Deolvg Title",
-                    "description": "Deolvg Deitipocrsn"
                 },
                 "initialSetup": {
                     "title": "Iniaitl Stuep",

--- a/src/renderer/assets/languages/dev.json
+++ b/src/renderer/assets/languages/dev.json
@@ -32,7 +32,8 @@
             }
         },
         "buttons": {
-            "quickPlay": "Qiuck paly"
+            "quickPlay": "Qiuck paly",
+            "readMore": "Raed more..."
         },
         "composables": {
             "useTerrainIcon": {
@@ -393,10 +394,6 @@
                 "devlogFeed": {
                     "latestChanges": "Lasett cngaehs"
                 },
-                "devlogEntry": {
-                    "title": "Deolvg Title",
-                    "description": "Deolvg Deitipocrsn"
-                },
                 "preloader": {
                     "loading": "Lndiaog",
                     "loadingFonts": "Lndiaog ftnos",
@@ -429,6 +426,10 @@
                     "couldNotUploadLog": "Culod not upolad log.",
                     "reload": "Rolead",
                     "quitToDesktop": "Quit to Dektosp"
+                },
+                "devlogEntry": {
+                    "title": "Deolvg Title",
+                    "description": "Deolvg Deitipocrsn"
                 },
                 "initialSetup": {
                     "title": "Iniaitl Stuep",

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -2224,6 +2224,10 @@
                 "devlogFeed": {
                     "latestChanges": "Latest changes"
                 },
+                "devlogEntry": {
+                    "title": "Devlog Title",
+                    "description": "Devlog Description"
+                },
                 "preloader": {
                     "loading": "Loading",
                     "loadingFonts": "Loading fonts",
@@ -2256,10 +2260,6 @@
                     "couldNotUploadLog": "Could not upload log.",
                     "reload": "Reload",
                     "quitToDesktop": "Quit to Desktop"
-                },
-                "devlogEntry": {
-                    "title": "Devlog Title",
-                    "description": "Devlog Description"
                 },
                 "initialSetup": {
                     "title": "Initial Setup",

--- a/src/renderer/assets/languages/en.json
+++ b/src/renderer/assets/languages/en.json
@@ -1863,7 +1863,8 @@
             }
         },
         "buttons": {
-            "quickPlay": "Quick play"
+            "quickPlay": "Quick play",
+            "readMore": "Read more..."
         },
         "composables": {
             "useTerrainIcon": {
@@ -2224,10 +2225,6 @@
                 "devlogFeed": {
                     "latestChanges": "Latest changes"
                 },
-                "devlogEntry": {
-                    "title": "Devlog Title",
-                    "description": "Devlog Description"
-                },
                 "preloader": {
                     "loading": "Loading",
                     "loadingFonts": "Loading fonts",
@@ -2260,6 +2257,10 @@
                     "couldNotUploadLog": "Could not upload log.",
                     "reload": "Reload",
                     "quitToDesktop": "Quit to Desktop"
+                },
+                "devlogEntry": {
+                    "title": "Devlog Title",
+                    "description": "Devlog Description"
                 },
                 "initialSetup": {
                     "title": "Initial Setup",

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -3868,7 +3868,8 @@
             }
         },
         "buttons": {
-            "quickPlay": null
+            "quickPlay": null,
+            "readMore": null
         },
         "composables": {
             "useTerrainIcon": {
@@ -4229,10 +4230,6 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
-                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4265,6 +4262,10 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
+                },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/fr.json
+++ b/src/renderer/assets/languages/fr.json
@@ -4229,6 +4229,10 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
+                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4261,10 +4265,6 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
-                },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -4198,6 +4198,10 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
+                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4230,10 +4234,6 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
-                },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/ru.json
+++ b/src/renderer/assets/languages/ru.json
@@ -3837,7 +3837,8 @@
             }
         },
         "buttons": {
-            "quickPlay": null
+            "quickPlay": null,
+            "readMore": null
         },
         "composables": {
             "useTerrainIcon": {
@@ -4198,10 +4199,6 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
-                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4234,6 +4231,10 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
+                },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -4340,6 +4340,10 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
+                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4372,10 +4376,6 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
-                },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/assets/languages/zh.json
+++ b/src/renderer/assets/languages/zh.json
@@ -3979,7 +3979,8 @@
             }
         },
         "buttons": {
-            "quickPlay": null
+            "quickPlay": null,
+            "readMore": null
         },
         "composables": {
             "useTerrainIcon": {
@@ -4340,10 +4341,6 @@
                 "devlogFeed": {
                     "latestChanges": null
                 },
-                "devlogEntry": {
-                    "title": null,
-                    "description": null
-                },
                 "preloader": {
                     "loading": null,
                     "loadingFonts": null,
@@ -4376,6 +4373,10 @@
                     "couldNotUploadLog": null,
                     "reload": null,
                     "quitToDesktop": null
+                },
+                "devlogEntry": {
+                    "title": null,
+                    "description": null
                 },
                 "initialSetup": {
                     "title": null,

--- a/src/renderer/components/misc/DevlogEntry.vue
+++ b/src/renderer/components/misc/DevlogEntry.vue
@@ -5,7 +5,13 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <div>
+    <component
+        :is="entry?.link ? 'button' : 'div'"
+        class="dev-entry"
+        :class="{ clickable: !!entry?.link }"
+        :type="entry?.link ? 'button' : undefined"
+        @click="openEntry"
+    >
         <div class="dev-title">
             {{ title }}
         </div>
@@ -13,19 +19,52 @@ SPDX-License-Identifier: MIT
             {{ formatDistanceToNow(entry.published, { addSuffix: true }) }}
         </div>
         <div class="dev-desc">{{ description }}</div>
-    </div>
+        <div v-if="entry?.link" class="dev-more">{{ t("lobby.components.misc.devlogEntry.readMore") }}</div>
+    </component>
 </template>
 <script lang="ts" setup>
 import { NewsFeedData } from "@main/services/news.service";
 import { formatDistanceToNow } from "date-fns";
 import { computed } from "vue";
+import { useTypedI18n } from "@renderer/i18n";
+import { shellApi } from "@renderer/api/shell";
+
+const { t } = useTypedI18n();
 
 const { entry } = defineProps<{ entry: NewsFeedData | undefined }>();
 
 const title = computed(() => entry?.title?.replace(" ⇀ Microblog ★ Beyond All Reason RTS", ""));
 const description = computed(() => entry?.description?.split("|")[1]?.trim());
+
+const openEntry = () => {
+    if (entry?.link) shellApi.openInBrowser(entry.link);
+};
 </script>
 <style lang="css" scoped>
+.dev-entry {
+    display: block;
+    width: 100%;
+    text-align: left;
+    margin-bottom: 15px;
+    padding: 10px;
+    border: none;
+    border-left: 2px solid rgba(255, 255, 255, 0.15);
+    background: rgba(0, 0, 0, 0.35);
+    color: inherit;
+    font: inherit;
+}
+
+.dev-entry.clickable {
+    cursor: pointer;
+    transition: 0.1s all;
+}
+
+.dev-entry.clickable:hover,
+.dev-entry.clickable:focus-visible {
+    background: rgba(0, 0, 0, 0.6);
+    border-left-color: #ffcc00;
+}
+
 .dev-title {
     font-size: 1.2em;
     font-weight: semibold;
@@ -43,8 +82,17 @@ const description = computed(() => entry?.description?.split("|")[1]?.trim());
     color: rgba(255, 255, 255, 0.8);
     filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
     font-size: 1em;
-    margin-bottom: 15px;
-    overflow-x: hidden;
-    text-overflow: ellipsis;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+}
+
+.dev-more {
+    margin-top: 5px;
+    font-size: 0.8em;
+    font-weight: 600;
+    color: #ffcc00;
 }
 </style>

--- a/src/renderer/components/misc/DevlogEntry.vue
+++ b/src/renderer/components/misc/DevlogEntry.vue
@@ -5,83 +5,84 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-    <component
-        :is="entry?.link ? 'button' : 'div'"
-        class="dev-entry"
-        :class="{ clickable: !!entry?.link }"
-        :type="entry?.link ? 'button' : undefined"
-        @click="openEntry"
-    >
-        <div class="dev-title">
-            {{ title }}
-        </div>
-        <div v-if="entry?.published" class="dev-date">
+    <button class="dev-entry" type="button" @click="openEntry">
+        <span class="dev-title">{{ title }}</span>
+        <span v-if="entry.published" class="dev-date">
             {{ formatDistanceToNow(entry.published, { addSuffix: true }) }}
-        </div>
-        <div class="dev-desc">{{ description }}</div>
-        <div v-if="entry?.link" class="dev-more">{{ t("lobby.components.misc.devlogEntry.readMore") }}</div>
-    </component>
+        </span>
+        <span ref="descriptionEl" class="dev-desc">{{ description }}</span>
+        <span v-if="isTruncated" class="dev-more">{{ t("lobby.buttons.readMore") }}</span>
+    </button>
 </template>
 <script lang="ts" setup>
-import { NewsFeedData } from "@main/services/news.service";
+import { NewsFeedEntry } from "@main/services/news.service";
 import { formatDistanceToNow } from "date-fns";
-import { computed } from "vue";
+import { computed, onMounted, ref, useTemplateRef } from "vue";
+import { useResizeObserver } from "@vueuse/core";
 import { useTypedI18n } from "@renderer/i18n";
 import { shellApi } from "@renderer/api/shell";
 
 const { t } = useTypedI18n();
 
-const { entry } = defineProps<{ entry: NewsFeedData | undefined }>();
+const { entry } = defineProps<{ entry: NewsFeedEntry }>();
 
-const title = computed(() => entry?.title?.replace(" ⇀ Microblog ★ Beyond All Reason RTS", ""));
-const description = computed(() => entry?.description?.split("|")[1]?.trim());
+const title = computed(() => entry.title?.replace(" ⇀ Microblog ★ Beyond All Reason RTS", ""));
+// The feed prefixes the body with "<author> | ", and bodies contain pipes of their own.
+const description = computed(() => entry.description?.split("|").slice(1).join("|").trim());
+
+// "Read more" is only honest when the preview actually hides something, which depends on how
+// the clamped text lays out rather than on the entry itself.
+const descriptionEl = useTemplateRef<HTMLElement>("descriptionEl");
+const isTruncated = ref(false);
+const measure = () => {
+    const el = descriptionEl.value;
+    isTruncated.value = !!entry.link && !!el && el.scrollHeight > el.clientHeight;
+};
+onMounted(measure);
+useResizeObserver(descriptionEl, measure);
 
 const openEntry = () => {
-    if (entry?.link) shellApi.openInBrowser(entry.link);
+    if (entry.link) shellApi.openInBrowser(entry.link);
 };
 </script>
 <style lang="css" scoped>
 .dev-entry {
     display: block;
-    width: 100%;
-    text-align: left;
-    margin-bottom: 15px;
+    inline-size: 100%;
+    margin-block-end: 15px;
     padding: 10px;
-    border: none;
-    border-left: 2px solid rgba(255, 255, 255, 0.15);
+    border-inline-start: 2px solid rgba(255, 255, 255, 0.15);
     background: rgba(0, 0, 0, 0.35);
-    color: inherit;
-    font: inherit;
-}
-
-.dev-entry.clickable {
-    cursor: pointer;
     transition: 0.1s all;
 }
 
-.dev-entry.clickable:hover,
-.dev-entry.clickable:focus-visible {
+.dev-entry:hover,
+.dev-entry:focus-visible {
     background: rgba(0, 0, 0, 0.6);
-    border-left-color: #ffcc00;
+    border-inline-start-color: var(--accent-color);
+}
+
+.dev-title,
+.dev-date,
+.dev-desc,
+.dev-more {
+    display: block;
+    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
 }
 
 .dev-title {
     font-size: 1.2em;
     font-weight: semibold;
-    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
 }
 
 .dev-date {
     font-size: 0.8em;
-    margin-bottom: 5px;
-    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
+    margin-block-end: 5px;
     color: rgba(255, 255, 255, 0.6);
 }
 
 .dev-desc {
     color: rgba(255, 255, 255, 0.8);
-    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
-    font-size: 1em;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -90,9 +91,9 @@ const openEntry = () => {
 }
 
 .dev-more {
-    margin-top: 5px;
+    margin-block-start: 5px;
     font-size: 0.8em;
     font-weight: 600;
-    color: #ffcc00;
+    color: var(--accent-color);
 }
 </style>

--- a/src/renderer/components/misc/NewsTile.vue
+++ b/src/renderer/components/misc/NewsTile.vue
@@ -128,7 +128,7 @@ const openNews = () => {
         transition: 0.2s opacity;
         .cta {
             margin-top: 20px;
-            color: #ffcc00;
+            color: var(--accent-color);
             font-weight: 600;
             cursor: pointer;
         }

--- a/src/renderer/styles/_document.scss
+++ b/src/renderer/styles/_document.scss
@@ -28,6 +28,7 @@
 }
 :root {
     --background: #000;
+    --accent-color: #ffcc00;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.6);

--- a/tests/unit/renderer/devlog-entry.spec.ts
+++ b/tests/unit/renderer/devlog-entry.spec.ts
@@ -2,20 +2,22 @@
 //
 // SPDX-License-Identifier: MIT
 
-import type { NewsFeedData } from "@main/services/news.service";
+import type { NewsFeedEntry } from "@main/services/news.service";
+import enTranslation from "@renderer/assets/languages/en.json";
 import DevlogEntry from "@renderer/components/misc/DevlogEntry.vue";
-import { mount } from "@vue/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const openInBrowser = vi.hoisted(() => vi.fn());
 
-vi.mock("@renderer/i18n", () => ({ useTypedI18n: () => ({ t: (key: string) => key }) }));
 vi.mock("@renderer/api/shell", () => ({ shellApi: { openInBrowser } }));
 
 const link = "https://www.beyondallreason.info/microblogs/some-update";
+const readMore = enTranslation.lobby.buttons.readMore;
 
-function entry(overrides: Partial<NewsFeedData> = {}): NewsFeedData {
+function entry(overrides: Partial<NewsFeedEntry> = {}): NewsFeedEntry {
     return {
+        id: "some-update",
         title: "Some update ⇀ Microblog ★ Beyond All Reason RTS",
         description: "author | The body of the entry.",
         published: new Date().toISOString(),
@@ -24,46 +26,72 @@ function entry(overrides: Partial<NewsFeedData> = {}): NewsFeedData {
     };
 }
 
-function mountEntry(entryProp: NewsFeedData | undefined) {
-    return mount(DevlogEntry, { props: { entry: entryProp } });
+// jsdom does not lay text out, so every element reports a height of 0 and the line clamp can
+// never overflow on its own. Give the clamped preview the metrics it would have in a browser.
+function previewOf(totalLines: number) {
+    const lineHeight = 20;
+    for (const [property, value] of [
+        ["clientHeight", 3 * lineHeight],
+        ["scrollHeight", totalLines * lineHeight],
+    ] as const) {
+        vi.spyOn(HTMLElement.prototype, property, "get").mockImplementation(function (this: HTMLElement) {
+            return this.classList.contains("dev-desc") ? value : 0;
+        });
+    }
+}
+
+async function mountEntry(entryProp: NewsFeedEntry) {
+    const wrapper = mount(DevlogEntry, { props: { entry: entryProp }, attachTo: document.body });
+    // The overflow check runs on mount, so its result only reaches the DOM on the next tick.
+    await flushPromises();
+    return wrapper;
 }
 
 describe("DevlogEntry", () => {
     beforeEach(() => {
         openInBrowser.mockReset();
+        previewOf(10);
     });
 
-    // The entry was plain text, so there was no way to read the rest of a truncated post.
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    // The entry was plain text, so there was no way to reach the post it previews.
     it("opens the entry in the browser when clicked", async () => {
-        const wrapper = mountEntry(entry());
+        const wrapper = await mountEntry(entry());
 
         await wrapper.trigger("click");
 
         expect(openInBrowser).toHaveBeenCalledWith(link);
     });
 
-    it("renders as a button so it is keyboard reachable", () => {
-        expect(mountEntry(entry()).element.tagName).toBe("BUTTON");
+    it("renders as a button so it is keyboard reachable", async () => {
+        expect((await mountEntry(entry())).element.tagName).toBe("BUTTON");
     });
 
-    it("shows a read more affordance when there is somewhere to go", () => {
-        expect(mountEntry(entry()).text()).toContain("lobby.components.misc.devlogEntry.readMore");
+    it("keeps the whole body when the description contains pipes", async () => {
+        const wrapper = await mountEntry(entry({ description: "author | Before | after." }));
+
+        expect(wrapper.get(".dev-desc").text()).toBe("Before | after.");
     });
 
-    // Feed entries are not guaranteed to carry a link, and a dead button is worse than plain text.
+    it("shows a read more affordance once the preview is clamped", async () => {
+        expect((await mountEntry(entry())).text()).toContain(readMore);
+    });
+
+    // A short entry is fully visible, so pointing at "read more" would lead nowhere new.
+    it("hides the read more affordance when the whole entry fits", async () => {
+        previewOf(2);
+
+        expect((await mountEntry(entry())).text()).not.toContain(readMore);
+    });
+
+    // Feed entries are not guaranteed to carry a link.
     it("stays inert when the feed entry has no link", async () => {
-        const wrapper = mountEntry(entry({ link: undefined }));
+        const wrapper = await mountEntry(entry({ link: undefined }));
 
-        expect(wrapper.element.tagName).toBe("DIV");
-        expect(wrapper.text()).not.toContain("lobby.components.misc.devlogEntry.readMore");
-
-        await wrapper.trigger("click");
-
-        expect(openInBrowser).not.toHaveBeenCalled();
-    });
-
-    it("survives an undefined entry", async () => {
-        const wrapper = mountEntry(undefined);
+        expect(wrapper.text()).not.toContain(readMore);
 
         await wrapper.trigger("click");
 

--- a/tests/unit/renderer/devlog-entry.spec.ts
+++ b/tests/unit/renderer/devlog-entry.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 The BAR Lobby Authors
+//
+// SPDX-License-Identifier: MIT
+
+import type { NewsFeedData } from "@main/services/news.service";
+import DevlogEntry from "@renderer/components/misc/DevlogEntry.vue";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const openInBrowser = vi.hoisted(() => vi.fn());
+
+vi.mock("@renderer/i18n", () => ({ useTypedI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("@renderer/api/shell", () => ({ shellApi: { openInBrowser } }));
+
+const link = "https://www.beyondallreason.info/microblogs/some-update";
+
+function entry(overrides: Partial<NewsFeedData> = {}): NewsFeedData {
+    return {
+        title: "Some update ⇀ Microblog ★ Beyond All Reason RTS",
+        description: "author | The body of the entry.",
+        published: new Date().toISOString(),
+        link,
+        ...overrides,
+    };
+}
+
+function mountEntry(entryProp: NewsFeedData | undefined) {
+    return mount(DevlogEntry, { props: { entry: entryProp } });
+}
+
+describe("DevlogEntry", () => {
+    beforeEach(() => {
+        openInBrowser.mockReset();
+    });
+
+    // The entry was plain text, so there was no way to read the rest of a truncated post.
+    it("opens the entry in the browser when clicked", async () => {
+        const wrapper = mountEntry(entry());
+
+        await wrapper.trigger("click");
+
+        expect(openInBrowser).toHaveBeenCalledWith(link);
+    });
+
+    it("renders as a button so it is keyboard reachable", () => {
+        expect(mountEntry(entry()).element.tagName).toBe("BUTTON");
+    });
+
+    it("shows a read more affordance when there is somewhere to go", () => {
+        expect(mountEntry(entry()).text()).toContain("lobby.components.misc.devlogEntry.readMore");
+    });
+
+    // Feed entries are not guaranteed to carry a link, and a dead button is worse than plain text.
+    it("stays inert when the feed entry has no link", async () => {
+        const wrapper = mountEntry(entry({ link: undefined }));
+
+        expect(wrapper.element.tagName).toBe("DIV");
+        expect(wrapper.text()).not.toContain("lobby.components.misc.devlogEntry.readMore");
+
+        await wrapper.trigger("click");
+
+        expect(openInBrowser).not.toHaveBeenCalled();
+    });
+
+    it("survives an undefined entry", async () => {
+        const wrapper = mountEntry(undefined);
+
+        await wrapper.trigger("click");
+
+        expect(openInBrowser).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #702.

### AI / LLM usage statement

This PR was written with AI assistance (Claude, agentic coding). The disclosure was missing from the original description — that was my mistake, and the reviews here are fair.

To be straight with you about verification: the change is covered by unit tests, typecheck, lint and format, but it has **not** been run in the client by a human, so I cannot make the "I tested this in the app" statement the AI policy asks for. @Hectate — that is the honest answer to your question, and I would rather say so than claim a screenshot I do not have. If that is disqualifying under the policy, please close it; the duplicate-key problem it surfaced is worth an issue on its own either way.

### Problem

Dev blog entries in the News view are plain text: no way to navigate to an entry, entries longer than the preview are cut off with no indication, and no link back to the source.

### What the review found, and what changed

**The missing translation string (@Hectate).** `readMore` was added under a *second* `lobby.components.misc.devlogEntry` key. The generator keeps the last of a duplicated key, so the new string was dropped and the entry rendered a raw translation path. The string now lives at `lobby.buttons.readMore` — a generic affordance does not belong to one component, and it cannot collide with the existing `devlogEntry` section there. The duplicate section is gone.

The reason this passed CI *and* passed my own test is the same reason: the test mocked `@renderer/i18n` so `t()` returned its own key, which is true whether or not the string exists. That mock is gone; the test uses the real messages from `tests/setup.renderer.mts` and asserts against the value read from `en.json`, so a dropped string now fails the suite.

**Invalid button content (@burnhamrobertp).** The children are `<span>`s set to `display: block` instead of `<div>`s.

**"Read more" on entries that fit.** It now appears only when the preview actually overflows, measured on the clamped element with a resize observer, rather than whenever a link exists.

**Wrong prop type.** `entry` is `NewsFeedEntry`, not `NewsFeedData`. You were right that it only type-checked because `FeedData` carries a `link` of its own. `DevlogFeed` always passes an entry, so the `undefined` handling (and its test) went with it.

**`split("|")[1]`.** Keeps everything after the leading `author |` prefix, so a body containing a pipe is no longer cut short.

**Redefined defaults and physical properties.** The redeclared button resets are gone (the CSS reset already unsets them) and the remaining box properties are logical (`inline-size`, `margin-block-end`, `border-inline-start`).

**Duplicated `#ffcc00`.** Now `--accent-color` on `:root`, used by both `DevlogEntry` and `NewsTile`. I stopped short of extracting a shared component: `NewsTile` is a hover-reveal image tile and this is a text row in a scroll list, so beyond the accent colour and the read-more idea they have little in common, and folding them together would be a larger change than this issue calls for. The keyboard reachability of news tiles is a real problem but a separate one — happy to open an issue for it.

**Stale test comment.** Removed.

`config.ts` is unchanged from the first push: `https://www.beyondallreason.info/microblogs` is added to `allowedUrlLinks`, without which `shellService.openInBrowser` rejects the URL with `url_not_allowed`.

### Validation

- `npm test` → 47 files, 377 tests passed
- `npm run typecheck` → node and web clean
- `npm run lint`, `npm run format`, `npm run generate-i18n-assets:check` → clean
- Not verified by running the client (see the disclosure above).
